### PR TITLE
Feature add testing

### DIFF
--- a/.github/GitVersion.yml
+++ b/.github/GitVersion.yml
@@ -1,0 +1,3 @@
+major-version-bump-message: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([\\w\\s-,/\\\\]*\\))?(!:|:.*\\n\\n((.+\\n)+\\n)?BREAKING CHANGE:\\s.+)"
+minor-version-bump-message: "^(feat)(\\([\\w\\s-,/\\\\]*\\))?:"
+patch-version-bump-message: "^(fix|perf)(\\([\\w\\s-,/\\\\]*\\))?:"

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -6,8 +6,28 @@ on:
       - main
 
 jobs:
-  release:
+  test:
+    name: Run Unit Tests
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test Midnight.SOAP.SDK.Tests/Midnight.SOAP.SDK.Tests.csproj --no-build --configuration Release --logger trx
+
+  release:
+    name: NuGet Release
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ success() }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,10 +47,9 @@ jobs:
       - name: Run GitVersion
         id: gitversion
         uses: gittools/actions/gitversion/execute@v4.1.0
-
-      - name: Update .csproj Version
-        run: |
-          sed -i "s/<Version>.*<\/Version>/<Version>${{ steps.gitversion.outputs.majorMinorPatch }}<\/Version>/" Midnight.SOAP.SDK/Midnight.SOAP.SDK.csproj
+        with:
+          updateProjectFiles: true
+          configFilePath: ./.github/GitVersion.yml
 
       - name: Restore dependencies
         run: dotnet restore Midnight.SOAP.SDK/Midnight.SOAP.SDK.csproj

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2025 MidnightMesh LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Midnight.SOAP.SDK.Tests/AuthenticationServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/AuthenticationServiceTests.cs
@@ -1,0 +1,28 @@
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class AuthenticationServiceTests
+    {
+        [Fact]
+        public async Task AuthenticateAsync_ReturnsValidationSoapHeader_WithCorrectDevToken()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            mockSoap
+                .Setup(s => s._GetWebServiceVersionAsync())
+                .ReturnsAsync("1.0.0");
+
+            var service = new AuthenticationService(mockSoap.Object);
+            var devToken = "test-token";
+
+            // Act
+            var result = await service.AuthenticateAsync(devToken);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(devToken, result.DevToken);
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/CustomerContactServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/CustomerContactServiceTests.cs
@@ -1,0 +1,196 @@
+using MidnightAPI;
+using Midnight.SOAP.SDK.RequestObjects.CustomerContactInputs;
+using Midnight.SOAP.SDK.ResponseObjects.CustomerContactOutputs;
+using Moq;
+using Xunit;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class CustomerContactServiceTests
+    {
+        [Fact]
+        public async Task CustomerContactInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var expectedResult = new CustomerContactInsertResult { ReturnCode = 0 };
+            var response = new CustomerContactInsertResponse
+            {
+                CustomerContactInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactInsertAsync(It.IsAny<CustomerContactInsertRequest>()))
+                .ReturnsAsync(response);
+
+            // Mock XmlParsing to return expectedResult
+            // If XmlParsing is static, use a wrapper or abstraction for testability.
+            // For this example, assume XmlParsing.DeserializeXmlToObject returns expectedResult.
+
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactListRequestBody
+            {
+                InputParameter = new CustomerContactListInputParameter()
+            };
+
+            // Act
+            var result = await service.CustomerContactInsertAsync(auth, request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerContactInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var errorResult = new CustomerContactInsertResult { ReturnCode = 1, ReturnErrors = new() { new() { Error = "Some error" } } };
+            var response = new CustomerContactInsertResponse
+            {
+                CustomerContactInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactInsertAsync(It.IsAny<CustomerContactInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactListRequestBody
+            {
+                InputParameter = new CustomerContactListInputParameter()
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerContactInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task CustomerContactListAsync_ReturnsResult_WhenSuccess()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var expectedResult = new CustomerContactListResult { ReturnCode = 0 };
+            var response = new CustomerContactListResponse
+            {
+                CustomerContactListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactListAsync(It.IsAny<CustomerContactListRequest>()))
+                .ReturnsAsync(response);
+
+            // Assume XmlParsing.DeserializeXmlToObject returns expectedResult.
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactListRequestBody
+            {
+                InputParameter = new CustomerContactListInputParameter()
+            };
+
+            // Act
+            var result = await service.CustomerContactListAsync(auth, request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerContactListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var errorResult = new CustomerContactListResult { ReturnCode = 1, ReturnErrors = new() { new() { Error = "Some error" } } };
+            var response = new CustomerContactListResponse
+            {
+                CustomerContactListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactListAsync(It.IsAny<CustomerContactListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactListRequestBody
+            {
+                InputParameter = new CustomerContactListInputParameter()
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerContactListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task CustomerContactUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var expectedResult = new CustomerContactUpdateResult { ReturnCode = 0 };
+            var response = new CustomerContactUpdateResponse
+            {
+                CustomerContactUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactUpdateAsync(It.IsAny<CustomerContactUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactUpdateRequestBody
+            {
+                InputParameter = new CustomerContactUpdateInputParameter { 
+                    CustomerContacts = new() { new CustomerContactUpdate { ContactID = 1 } } }
+            };
+
+            // Act
+            var result = await service.CustomerContactUpdateAsync(auth, request);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerContactUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            // Arrange
+            var mockSoap = new Mock<Service1Soap>();
+            var errorResult = new CustomerContactUpdateResult { ReturnCode = 1, ReturnErrors = new() { new() { Error = "Some error" } } };
+            var response = new CustomerContactUpdateResponse
+            {
+                CustomerContactUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+
+            mockSoap
+                .Setup(s => s.CustomerContactUpdateAsync(It.IsAny<CustomerContactUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerContactUpdateRequestBody
+            {
+                InputParameter = new CustomerContactUpdateInputParameter { 
+                CustomerContacts = new() { new CustomerContactUpdate { ContactID = 0 } }
+            }
+            };
+
+            // Act & Assert
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerContactUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/CustomerServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/CustomerServiceTests.cs
@@ -1,0 +1,212 @@
+using MidnightAPI;
+using Midnight.SOAP.SDK;
+using Midnight.SOAP.SDK.RequestObjects.CustomerInputs;
+using Midnight.SOAP.SDK.ResponseObjects.CustomerOutputs;
+using Moq;
+using Xunit;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class CustomerServiceTests
+    {
+        [Fact]
+        public async Task CustomerPostageAccountListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerPostageAccountListResponse
+            {
+                CustomerPostageAccountListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerPostageAccountListAsync(It.IsAny<CustomerPostageAccountListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerPostageAccountListRequestBody
+            {
+                InputParameter = new CustomerPostageAccountListInputParameter { CustomerID = 12345 }
+            };
+
+            var result = await service.CustomerPostageAccountListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerPostageAccountListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerPostageAccountListResponse
+            {
+                CustomerPostageAccountListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerPostageAccountListAsync(It.IsAny<CustomerPostageAccountListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerPostageAccountListRequestBody
+            {
+                InputParameter = new CustomerPostageAccountListInputParameter { CustomerID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerPostageAccountListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task CustomerListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerListResponse
+            {
+                CustomerListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerListAsync(It.IsAny<CustomerListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerListRequestBody
+            {
+                InputParameter = new CustomerListInputParameter()
+            };
+
+            var result = await service.CustomerListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerListResponse
+            {
+                CustomerListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerListAsync(It.IsAny<CustomerListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerListRequestBody
+            {
+                InputParameter = new CustomerListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task CustomerUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerUpdateResponse
+            {
+                CustomerUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerUpdateAsync(It.IsAny<CustomerUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerUpdateRequestBody
+            {
+                InputParameter = new CustomerUpdateInputParameter { CustomerCode = "CUST123" }
+            };
+
+            var result = await service.CustomerUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerUpdateResponse
+            {
+                CustomerUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerUpdateAsync(It.IsAny<CustomerUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerUpdateRequestBody
+            {
+                InputParameter = new CustomerUpdateInputParameter { CustomerCode = "CUST123" }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task CustomerInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerInsertResponse
+            {
+                CustomerInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerInsertAsync(It.IsAny<CustomerInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerInsertRequestBody
+            {
+                InputParameter = new CustomerInsertInputParameter()
+            };
+
+            var result = await service.CustomerInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CustomerInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerInsertResponse
+            {
+                CustomerInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.CustomerInsertAsync(It.IsAny<CustomerInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new CustomerService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerInsertRequestBody
+            {
+                InputParameter = new CustomerInsertInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CustomerInsertAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/DJBServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/DJBServiceTests.cs
@@ -1,0 +1,162 @@
+using MidnightAPI;
+using Midnight.SOAP.SDK;
+using Midnight.SOAP.SDK.RequestObjects.DJBInputs;
+using Midnight.SOAP.SDK.ResponseObjects.DJBOutputs;
+using Moq;
+using Xunit;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class DJBServiceTests
+    {
+        [Fact]
+        public async Task DJBJobStatusListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBJobStatusListResponse
+            {
+                DJBJobStatusListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBJobStatusListAsync(It.IsAny<DJBJobStatusListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBJobStatusListRequestBody
+            {
+                InputParameter = new DJBStatusListInputParameter()
+            };
+
+            var result = await service.DJBJobStatusListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task DJBJobStatusListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBJobStatusListResponse
+            {
+                DJBJobStatusListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBJobStatusListAsync(It.IsAny<DJBJobStatusListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBJobStatusListRequestBody
+            {
+                InputParameter = new DJBStatusListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.DJBJobStatusListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task DJBListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBListResponse
+            {
+                DJBListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBListAsync(It.IsAny<DJBListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBListRequestBody
+            {
+                InputParameter = new DJBListRequestInputParameter()
+            };
+
+            var result = await service.DJBListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task DJBListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBListResponse
+            {
+                DJBListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBListAsync(It.IsAny<DJBListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBListRequestBody
+            {
+                InputParameter = new DJBListRequestInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.DJBListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task DJBStatusUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBStatusUpdateResponse
+            {
+                DJBStatusUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBStatusUpdateAsync(It.IsAny<DJBStatusUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBStatusUpdateRequestBody
+            {
+                InputParameter = new DJBStatusUpdateInputParameter { DJBDetailID = 1, DJBStatusID = 2 }
+            };
+
+            var result = await service.DJBStatusUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task DJBStatusUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DJBStatusUpdateResponse
+            {
+                DJBStatusUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.DJBStatusUpdateAsync(It.IsAny<DJBStatusUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new DJBService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DJBStatusUpdateRequestBody
+            {
+                InputParameter = new DJBStatusUpdateInputParameter { DJBDetailID = 1, DJBStatusID = 2 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.DJBStatusUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/EstimateServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/EstimateServiceTests.cs
@@ -1,0 +1,285 @@
+using Midnight.SOAP.SDK.RequestObjects.EstimateInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class EstimateServiceTests
+    {
+        [Fact]
+        public async Task EstimateListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateListResponse
+            {
+                EstimateListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateListAsync(It.IsAny<EstimateListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateListRequestBody
+            {
+                InputParameter = new EstimateListInputParameter()
+            };
+
+            var result = await service.EstimateListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task EstimateListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateListResponse
+            {
+                EstimateListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateListAsync(It.IsAny<EstimateListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateListRequestBody
+            {
+                InputParameter = new EstimateListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.EstimateListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task EstimateDetailListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateDetailListResponse
+            {
+                EstimateDetailListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateDetailListAsync(It.IsAny<EstimateDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateDetailListRequestBody
+            {
+                InputParameter = new EstimateDetailListInputParameter { EstimateID = 1 }
+            };
+
+            var result = await service.EstimateDetailListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task EstimateDetailListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateDetailListResponse
+            {
+                EstimateDetailListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateDetailListAsync(It.IsAny<EstimateDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateDetailListRequestBody
+            {
+                InputParameter = new EstimateDetailListInputParameter { EstimateID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.EstimateDetailListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task EstimateInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateInsertResponse
+            {
+                EstimateInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateInsertAsync(It.IsAny<EstimateInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateInsertRequestBody();
+
+            var result = await service.EstimateInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task EstimateInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateInsertResponse
+            {
+                EstimateInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateInsertAsync(It.IsAny<EstimateInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateInsertRequestBody();
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.EstimateInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task PrintTemplatePreviewPriceAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PrintTemplatePreviewPriceResponse
+            {
+                PrintTemplatePreviewPriceResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.PrintTemplatePreviewPriceAsync(It.IsAny<PrintTemplatePreviewPriceRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PrintTemplatePreviewPriceRequestBody { ProjectTypeID = 1, CustomerID = 1, Quantity = 1 };
+
+            var result = await service.PrintTemplatePreviewPriceAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task PrintTemplatePreviewPriceAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PrintTemplatePreviewPriceResponse
+            {
+                PrintTemplatePreviewPriceResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.PrintTemplatePreviewPriceAsync(It.IsAny<PrintTemplatePreviewPriceRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PrintTemplatePreviewPriceRequestBody { ProjectTypeID = 1, CustomerID = 1, Quantity = 1 };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.PrintTemplatePreviewPriceAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task WideFormatPreviewPriceAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WideFormatPreviewPriceResponse
+            {
+                WideFormatPreviewPriceResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.WideFormatPreviewPriceAsync(It.IsAny<WideFormatPreviewPriceRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WideFormatPreviewPriceRequestBody { WideFormatProductTypeID = 1, CustomerID = 1, Quantity = 1 };
+
+            var result = await service.WideFormatPreviewPriceAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task WideFormatPreviewPriceAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WideFormatPreviewPriceResponse
+            {
+                WideFormatPreviewPriceResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.WideFormatPreviewPriceAsync(It.IsAny<WideFormatPreviewPriceRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WideFormatPreviewPriceRequestBody { WideFormatProductTypeID = 1, CustomerID = 1, Quantity = 1 };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.WideFormatPreviewPriceAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task EstimateUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateUpdateResponse
+            {
+                EstimateUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateUpdateAsync(It.IsAny<EstimateUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateUpdateRequestBody { EstimateID = 1 };
+
+            var result = await service.EstimateUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task EstimateUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EstimateUpdateResponse
+            {
+                EstimateUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.EstimateUpdateAsync(It.IsAny<EstimateUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new EstimateService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EstimateUpdateRequestBody { EstimateID = 1 };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.EstimateUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/InventoryItemServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/InventoryItemServiceTests.cs
@@ -1,0 +1,365 @@
+using Midnight.SOAP.SDK.RequestObjects.InventoryItemInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class InventoryItemServiceTests
+    {
+        [Fact]
+        public async Task InventoryItemLocationListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLocationListResponse
+            {
+                InventoryItemLocationListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLocationListAsync(It.IsAny<InventoryItemLocationListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLocationListRequestBody
+            {
+                InputParameter = new InventoryItemLocationListInputParameter()
+            };
+
+            var result = await service.InventoryItemLocationListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemLocationListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLocationListResponse
+            {
+                InventoryItemLocationListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLocationListAsync(It.IsAny<InventoryItemLocationListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLocationListRequestBody
+            {
+                InputParameter = new InventoryItemLocationListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemLocationListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task InventoryItemLotListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotListResponse
+            {
+                InventoryItemLotListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotListAsync(It.IsAny<InventoryItemLotListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotListRequestBody
+            {
+                InputParameter = new InventoryItemLotListInputParameter()
+            };
+
+            var result = await service.InventoryItemLotListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemLotListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotListResponse
+            {
+                InventoryItemLotListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotListAsync(It.IsAny<InventoryItemLotListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotListRequestBody
+            {
+                InputParameter = new InventoryItemLotListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemLotListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task InventoryItemLotNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotNewResponse
+            {
+                InventoryItemLotNewResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotNewAsync(It.IsAny<InventoryItemLotNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotNewRequestBody
+            {
+                InputParameter = new InventoryItemLotNewInputParameter()
+            };
+
+            var result = await service.InventoryItemLotNewAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemLotNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotNewResponse
+            {
+                InventoryItemLotNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotNewAsync(It.IsAny<InventoryItemLotNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotNewRequestBody
+            {
+                InputParameter = new InventoryItemLotNewInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemLotNewAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task InventoryItemTransactionTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemTransactionTypeListResponse
+            {
+                InventoryItemTransactionTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemTransactionTypeListAsync(It.IsAny<InventoryItemTransactionTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemTransactionTypeListRequestBody
+            {
+                InputParameter = new InventoryItemTransactionTypeListInputParameter()
+            };
+
+            var result = await service.InventoryItemTransactionTypeListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemTransactionTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemTransactionTypeListResponse
+            {
+                InventoryItemTransactionTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemTransactionTypeListAsync(It.IsAny<InventoryItemTransactionTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemTransactionTypeListRequestBody
+            {
+                InputParameter = new InventoryItemTransactionTypeListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemTransactionTypeListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task InventoryItemTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemTypeListResponse
+            {
+                InventoryItemTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemTypeListAsync(It.IsAny<InventoryItemTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemTypeListRequestBody
+            {
+                InputParameter = new InventoryItemTypeListInputParameter()
+            };
+
+            var result = await service.InventoryItemTypeListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemTypeListResponse
+            {
+                InventoryItemTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemTypeListAsync(It.IsAny<InventoryItemTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemTypeListRequestBody
+            {
+                InputParameter = new InventoryItemTypeListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemTypeListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task ItemRequestTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ItemRequestTypeListResponse
+            {
+                ItemRequestTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.ItemRequestTypeListAsync(It.IsAny<ItemRequestTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ItemRequestTypeListRequestBody
+            {
+                InputParameter = new ItemRequestTypeListInputParameter()
+            };
+
+            var result = await service.ItemRequestTypeListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task ItemRequestTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ItemRequestTypeListResponse
+            {
+                ItemRequestTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.ItemRequestTypeListAsync(It.IsAny<ItemRequestTypeListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ItemRequestTypeListRequestBody
+            {
+                InputParameter = new ItemRequestTypeListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.ItemRequestTypeListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task InventoryItemLotUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotUpdateResponse
+            {
+                InventoryItemLotUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotUpdateAsync(It.IsAny<InventoryItemLotUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotUpdateRequestBody
+            {
+                InputParameter = new InventoryItemLotUpdateInputParameter 
+                { 
+                    ItemLot = new InventoryItemLotUpdate { ItemLotID = 1 } 
+                }
+            };
+
+            var result = await service.InventoryItemLotUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task InventoryItemLotUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new InventoryItemLotUpdateResponse
+            {
+                InventoryItemLotUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.InventoryItemLotUpdateAsync(It.IsAny<InventoryItemLotUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new InventoryItemService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new InventoryItemLotUpdateRequestBody
+            {
+                InputParameter = new InventoryItemLotUpdateInputParameter
+                {
+                    ItemLot = new InventoryItemLotUpdate { ItemLotID = 1 }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.InventoryItemLotUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/JobCostingServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/JobCostingServiceTests.cs
@@ -1,0 +1,354 @@
+using MidnightAPI;
+using Midnight.SOAP.SDK;
+using Midnight.SOAP.SDK.RequestObjects.JobCostInputs;
+using Midnight.SOAP.SDK.ResponseObjects.JobCostOutputs;
+using Moq;
+using Xunit;
+using System;
+using System.Collections.Generic;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class JobCostingServiceTests
+    {
+        [Fact]
+        public async Task JobCostingJobOutAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostingJobOutResponse
+            {
+                JobCostingJobOutResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostingJobOutAsync(It.IsAny<JobCostingJobOutRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobOutRequestBody { InputParameter = new JobOutInputParameter() };
+
+            var result = await service.JobCostingJobOutAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobCostingJobOutAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostingJobOutResponse
+            {
+                JobCostingJobOutResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostingJobOutAsync(It.IsAny<JobCostingJobOutRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobOutRequestBody { InputParameter = new JobOutInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobCostingJobOutAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task JobCostProductionTimeEntryAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostProductionTimeEntryResponse
+            {
+                JobCostProductionTimeEntryResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostProductionTimeEntryAsync(It.IsAny<JobCostProductionTimeEntryRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProductionTimeEntryRequestBody 
+            { 
+                InputParameter = new ProductionTimeEntryInputParameter { EmployeeID = 1234 } 
+            };
+
+            var result = await service.JobCostProductionTimeEntryAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobCostProductionTimeEntryAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostProductionTimeEntryResponse
+            {
+                JobCostProductionTimeEntryResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostProductionTimeEntryAsync(It.IsAny<JobCostProductionTimeEntryRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProductionTimeEntryRequestBody 
+            { 
+                InputParameter = new ProductionTimeEntryInputParameter { EmployeeID = 1234 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobCostProductionTimeEntryAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task JobCostServiceTimeEntry_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostServiceTimeEntryResponse
+            {
+                JobCostServiceTimeEntryResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostServiceTimeEntryAsync(It.IsAny<JobCostServiceTimeEntryRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceTimeEntryRequestBody 
+            { 
+                EmployeeID = 123,
+                ActivityDate = "2024-01-01",
+                JobCostItems = new List<ServiceTimeEntryRequestItem>
+                {
+                    new ServiceTimeEntryRequestItem
+                    {
+                        OperationCode = "OP123",
+                        HelpersCount = 2,
+                        TotalTime = 1.0m
+                    }
+                }
+            };
+
+            var result = await service.JobCostServiceTimeEntry(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobCostServiceTimeEntry_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostServiceTimeEntryResponse
+            {
+                JobCostServiceTimeEntryResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostServiceTimeEntryAsync(It.IsAny<JobCostServiceTimeEntryRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceTimeEntryRequestBody 
+            { 
+                EmployeeID = 123,
+                ActivityDate = "2024-01-01",
+                JobCostItems = new List<ServiceTimeEntryRequestItem>
+                {
+                    new ServiceTimeEntryRequestItem
+                    {
+                        OperationCode = "OP123",
+                        HelpersCount = 2,
+                        TotalTime = 1.0m
+                    }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobCostServiceTimeEntry(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionOtherJobCostInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionOtherJobCostInsertResponse
+            {
+                OrderVersionOtherJobCostInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionOtherJobCostInsertAsync(It.IsAny<OrderVersionOtherJobCostInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionOtherJobCostInsertRequestBody { OrderID = 1, Date = "01/01/2025", VersionID = 1 };
+
+            var result = await service.OrderVersionOtherJobCostInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionOtherJobCostInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionOtherJobCostInsertResponse
+            {
+                OrderVersionOtherJobCostInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionOtherJobCostInsertAsync(It.IsAny<OrderVersionOtherJobCostInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionOtherJobCostInsertRequestBody { Date = "01/01/2025", OrderID = 1, VersionID = 1 };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionOtherJobCostInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task JobCostDetailTempListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostDetailTempListResponse
+            {
+                JobCostDetailTempListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostDetailTempListAsync(It.IsAny<JobCostDetailTempListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+
+            var result = await service.JobCostDetailTempListAsync(auth);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobCostDetailTempListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostDetailTempListResponse
+            {
+                JobCostDetailTempListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostDetailTempListAsync(It.IsAny<JobCostDetailTempListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobCostDetailTempListAsync(auth);
+            });
+        }
+
+        [Fact]
+        public async Task JobCostOrderVersionServiceSummaryListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostOrderVersionServiceSummaryListResponse
+            {
+                JobCostOrderVersionServiceSummaryListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostOrderVersionServiceSummaryListAsync(It.IsAny<JobCostOrderVersionServiceSummaryListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var orderNumber = "ORD123";
+            var jobCostingDate = "2024-05-01";
+
+            var result = await service.JobCostOrderVersionServiceSummaryListAsync(auth, orderNumber, jobCostingDate);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobCostOrderVersionServiceSummaryListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobCostOrderVersionServiceSummaryListResponse
+            {
+                JobCostOrderVersionServiceSummaryListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.JobCostOrderVersionServiceSummaryListAsync(It.IsAny<JobCostOrderVersionServiceSummaryListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var orderNumber = "ORD123";
+            var jobCostingDate = "2024-05-01";
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobCostOrderVersionServiceSummaryListAsync(auth, orderNumber, jobCostingDate);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionOtherJobCostUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionOtherJobCostUpdateResponse
+            {
+                OrderVersionOtherJobCostUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionOtherJobCostUpdateAsync(It.IsAny<OrderVersionOtherJobCostUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionOtherJobCostUpdateRequestBody { OrderVersionOtherJobCostID = 1, Date = "01/01/2025" };
+
+            var result = await service.OrderVersionOtherJobCostUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionOtherJobCostUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionOtherJobCostUpdateResponse
+            {
+                OrderVersionOtherJobCostUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionOtherJobCostUpdateAsync(It.IsAny<OrderVersionOtherJobCostUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new JobCostingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionOtherJobCostUpdateRequestBody { OrderVersionOtherJobCostID = 1, Date = "01/01/2025" };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionOtherJobCostUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/Midnight.SOAP.SDK.Tests.csproj
+++ b/Midnight.SOAP.SDK.Tests/Midnight.SOAP.SDK.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Midnight.SOAP.SDK\Midnight.SOAP.SDK.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Midnight.SOAP.SDK.Tests/OrderServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderServiceTests.cs
@@ -1,0 +1,307 @@
+using Midnight.SOAP.SDK.RequestObjects.OrderInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderServiceTests
+    {
+        [Fact]
+        public async Task OrderListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderListResponse
+            {
+                OrderListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderListAsync(It.IsAny<OrderListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderListRequestBody { InputParameter = new OrderListInputParameter() };
+
+            var result = await service.OrderListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderListResponse
+            {
+                OrderListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderListAsync(It.IsAny<OrderListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderListRequestBody { InputParameter = new OrderListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderQuickAddAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderQuickAddResponse
+            {
+                OrderQuickAddResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderQuickAddAsync(It.IsAny<OrderQuickAddRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderQuickAddRequestBody { Order = new OrderQuickAddInputParameter() };
+
+            var result = await service.OrderQuickAddAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderQuickAddAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderQuickAddResponse
+            {
+                OrderQuickAddResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderQuickAddAsync(It.IsAny<OrderQuickAddRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderQuickAddRequestBody { Order = new OrderQuickAddInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderQuickAddAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderUpdateResponse
+            {
+                OrderUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderUpdateAsync(It.IsAny<OrderUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderUpdateRequestBody { InputParameter = new OrderUpdateInputParameter { OrderID = 1 } };
+
+            var result = await service.OrderUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderUpdateResponse
+            {
+                OrderUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderUpdateAsync(It.IsAny<OrderUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderUpdateRequestBody { InputParameter = new OrderUpdateInputParameter { OrderID = 1 } };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderNewResponse
+            {
+                OrderNewResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderNewAsync(It.IsAny<OrderNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderNewRequestBody { Order = new OrderNewInputParameter() };
+
+            var result = await service.OrderNewAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderNewResponse
+            {
+                OrderNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderNewAsync(It.IsAny<OrderNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderNewRequestBody { Order = new OrderNewInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderNewAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderAddAttachmentAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderAddAttachmentResponse
+            {
+                OrderAddAttachmentResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderAddAttachmentAsync(It.IsAny<OrderAddAttachmentRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var fileContent = new byte[] { 1, 2, 3 };
+            var fileName = "test.pdf";
+            int? documentTypeId = 1;
+            int orderId = 123;
+
+            var result = await service.OrderAddAttachmentAsync(auth, fileContent, fileName, documentTypeId, orderId);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderAddAttachmentAsync_ReturnsError_WhenFileContentIsZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var fileContent = new byte[] { 0, 0, 0 };
+            var fileName = "test.pdf";
+            int? documentTypeId = 1;
+            int orderId = 123;
+
+            var result = await service.OrderAddAttachmentAsync(auth, fileContent, fileName, documentTypeId, orderId);
+
+            Assert.NotNull(result);
+            Assert.Equal(-1, result.ReturnCode);
+            Assert.Contains(result.ReturnErrors, e => e.Error != null 
+                && e.Error.Contains("File content byte array must be non-zero"));
+        }
+
+        [Fact]
+        public async Task OrderAddAttachmentAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderAddAttachmentResponse
+            {
+                OrderAddAttachmentResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderAddAttachmentAsync(It.IsAny<OrderAddAttachmentRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var fileContent = new byte[] { 1, 2, 3 };
+            var fileName = "test.pdf";
+            int? documentTypeId = 1;
+            int orderId = 123;
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderAddAttachmentAsync(auth, fileContent, fileName, documentTypeId, orderId);
+            });
+        }
+
+        [Fact]
+        public async Task OrderShipmentNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderShipmentNewResponse
+            {
+                OrderShipmentNewResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderShipmentNewAsync(It.IsAny<OrderShipmentNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderShipmentNewRequestBody 
+            { 
+                OrderID = 1, ShippedDate = "01/01/2025", TrackingNo = "TR1234", VersionID = 1 
+            };
+
+            var result = await service.OrderShipmentNewAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderShipmentNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderShipmentNewResponse
+            {
+                OrderShipmentNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderShipmentNewAsync(It.IsAny<OrderShipmentNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderShipmentNewRequestBody
+            {
+                OrderID = 1,
+                ShippedDate = "01/01/2025",
+                TrackingNo = "TR1234",
+                VersionID = 1
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderShipmentNewAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/OrderVersionDetailServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderVersionDetailServiceTests.cs
@@ -1,0 +1,259 @@
+﻿using Midnight.SOAP.SDK.RequestObjects.OrderVersionDetailInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderVersionDetailServiceTests
+    {
+        [Fact]
+        public async Task OrderVersionDetailListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailListResponse
+            {
+                OrderVersionDetailListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailListAsync(It.IsAny<OrderVersionDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailListRequestBody
+            {
+                InputParameter = new OrderVersionDetailListInputParameter { VersionID = 12345 }
+            };
+
+            var result = await service.OrderVersionDetailListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailListResponse
+            {
+                OrderVersionDetailListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailListAsync(It.IsAny<OrderVersionDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailListRequestBody
+            {
+                InputParameter = new OrderVersionDetailListInputParameter { VersionID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDetailListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailInsertResponse
+            {
+                OrderVersionDetailInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailInsertAsync(It.IsAny<OrderVersionDetailInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailInsertRequestBody
+            {
+                InputParameter = new OrderVersionDetailInsertInputParameter()
+            };
+
+            var result = await service.OrderVersionDetailInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailInsertResponse
+            {
+                OrderVersionDetailInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailInsertAsync(It.IsAny<OrderVersionDetailInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailInsertRequestBody
+            {
+                InputParameter = new OrderVersionDetailInsertInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDetailInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailUpdateResponse
+            {
+                OrderVersionDetailUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailUpdateAsync(It.IsAny<OrderVersionDetailUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailUpdateRequestBody
+            {
+                InputParameter = new OrderVersionDetailUpdateInputParameter { OrderVersionDetailID = 12345 }
+            };
+
+            var result = await service.OrderVersionDetailUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailUpdateResponse
+            {
+                OrderVersionDetailUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailUpdateAsync(It.IsAny<OrderVersionDetailUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailUpdateRequestBody
+            {
+                InputParameter = new OrderVersionDetailUpdateInputParameter { OrderVersionDetailID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDetailUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailEstimatedTimeAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailEstimatedTimeResponse
+            {
+                OrderVersionDetailEstimatedTimeResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailEstimatedTimeAsync(It.IsAny<OrderVersionDetailEstimatedTimeRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailEstimatedTimeRequestBody
+            {
+                InputParameter = new OrderVersionDetailEstimatedTimeInputParameter()
+            };
+
+            var result = await service.OrderVersionDetailEstimatedTimeAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailEstimatedTimeAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailEstimatedTimeResponse
+            {
+                OrderVersionDetailEstimatedTimeResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailEstimatedTimeAsync(It.IsAny<OrderVersionDetailEstimatedTimeRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailEstimatedTimeRequestBody
+            {
+                InputParameter = new OrderVersionDetailEstimatedTimeInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDetailEstimatedTimeAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailDeleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailDeleteResponse
+            {
+                OrderVersionDetailDeleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailDeleteAsync(It.IsAny<OrderVersionDetailDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDetailDeleteInputParameter { OrderVersionDetailID = 12345 }
+            };
+
+            var result = await service.OrderVersionDetailDeleteAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDetailDeleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDetailDeleteResponse
+            {
+                OrderVersionDetailDeleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDetailDeleteAsync(It.IsAny<OrderVersionDetailDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDetailService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDetailDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDetailDeleteInputParameter { OrderVersionDetailID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDetailDeleteAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/OrderVersionDropServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderVersionDropServiceTests.cs
@@ -1,0 +1,209 @@
+using Midnight.SOAP.SDK.RequestObjects.OrderVersionDropInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderVersionDropServiceTests
+    {
+        [Fact]
+        public async Task OrderVersionDropListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropListResponse
+            {
+                OrderVersionDropListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropListAsync(It.IsAny<OrderVersionDropListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropListRequestBody
+            {
+                InputParameter = new OrderVersionDropListInputParameter { VersionID = 1 }
+            };
+
+            var result = await service.OrderVersionDropListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDropListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropListResponse
+            {
+                OrderVersionDropListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropListAsync(It.IsAny<OrderVersionDropListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropListRequestBody
+            {
+                InputParameter = new OrderVersionDropListInputParameter { VersionID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDropListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDropInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropInsertResponse
+            {
+                OrderVersionDropInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropInsertAsync(It.IsAny<OrderVersionDropInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropInsertRequestBody
+            {
+                InputParameter = new OrderVersionDropInsertInputParameter()
+            };
+
+            var result = await service.OrderVersionDropInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDropInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropInsertResponse
+            {
+                OrderVersionDropInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropInsertAsync(It.IsAny<OrderVersionDropInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropInsertRequestBody
+            {
+                InputParameter = new OrderVersionDropInsertInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDropInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDropUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropUpdateResponse
+            {
+                OrderVersionDropUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropUpdateAsync(It.IsAny<OrderVersionDropUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropUpdateRequestBody
+            {
+                InputParameter = new OrderVersionDropUpdateInputParameter { OrderVersionDropID = 1 }
+            };
+
+            var result = await service.OrderVersionDropUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDropUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropUpdateResponse
+            {
+                OrderVersionDropUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropUpdateAsync(It.IsAny<OrderVersionDropUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropUpdateRequestBody
+            {
+                InputParameter = new OrderVersionDropUpdateInputParameter { OrderVersionDropID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDropUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDropDeleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropDeleteResponse
+            {
+                OrderVersionDropDeleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropDeleteAsync(It.IsAny<OrderVersionDropDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDropDeleteinputParameter { OrderVersionDropID = 1 }
+            };
+
+            var result = await service.OrderVersionDropDeleteAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDropDeleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDropDeleteResponse
+            {
+                OrderVersionDropDeleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDropDeleteAsync(It.IsAny<OrderVersionDropDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionDropService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDropDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDropDeleteinputParameter{ OrderVersionDropID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionDropDeleteAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/OrderVersionInventoryServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderVersionInventoryServiceTests.cs
@@ -1,0 +1,159 @@
+using Midnight.SOAP.SDK.RequestObjects.OrderVersionInventoryInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderVersionInventoryServiceTests
+    {
+        [Fact]
+        public async Task OrderVersionInventoryListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryListResponse
+            {
+                OrderVersionInventoryListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryListAsync(It.IsAny<OrderVersionInventoryListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryListRequestBody
+            {
+                InputParameter = new OrderVersionInventoryListInputParameter()
+            };
+
+            var result = await service.OrderVersionInventoryListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionInventoryListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryListResponse
+            {
+                OrderVersionInventoryListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryListAsync(It.IsAny<OrderVersionInventoryListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryListRequestBody
+            {
+                InputParameter = new OrderVersionInventoryListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionInventoryListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionInventoryUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryUpdateResponse
+            {
+                OrderVersionInventoryUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryUpdateAsync(It.IsAny<OrderVersionInventoryUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryUpdateRequestBody
+            {
+                InputParameter = new OrderVersionInventoryUpdateInputParameter { OrderInventoryID = 12345 }
+            };
+
+            var result = await service.OrderVersionInventoryUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionInventoryUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryUpdateResponse
+            {
+                OrderVersionInventoryUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryUpdateAsync(It.IsAny<OrderVersionInventoryUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryUpdateRequestBody
+            {
+                InputParameter = new OrderVersionInventoryUpdateInputParameter { OrderInventoryID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionInventoryUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionInventoryInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryInsertResponse
+            {
+                OrderVersionInventoryInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryInsertAsync(It.IsAny<OrderVersionInventoryInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryInsertRequestBody
+            {
+                InputParameter = new OrderVersionInventoryInsertInputParameter()
+            };
+
+            var result = await service.OrderVersionInventoryInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionInventoryInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionInventoryInsertResponse
+            {
+                OrderVersionInventoryInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionInventoryInsertAsync(It.IsAny<OrderVersionInventoryInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionInventoryService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionInventoryInsertRequestBody
+            {
+                InputParameter = new OrderVersionInventoryInsertInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionInventoryInsertAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/OrderVersionPostageServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderVersionPostageServiceTests.cs
@@ -1,0 +1,309 @@
+using Midnight.SOAP.SDK.RequestObjects.OrderVersionPostageInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderVersionPostageServiceTests
+    {
+        [Fact]
+        public async Task OrderVersionPostageInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageInsertResponse
+            {
+                OrderVersionPostageInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageInsertAsync(It.IsAny<OrderVersionPostageInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageInsertRequestBody
+            {
+                InputParameter = new OrderVersionPostageInsertInputParameter()
+            };
+
+            var result = await service.OrderVersionPostageInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageInsertResponse
+            {
+                OrderVersionPostageInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageInsertAsync(It.IsAny<OrderVersionPostageInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageInsertRequestBody
+            {
+                InputParameter = new OrderVersionPostageInsertInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageUpdateResponse
+            {
+                OrderVersionPostageUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageUpdateAsync(It.IsAny<OrderVersionPostageUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageUpdateRequestBody
+            {
+                InputParameter = new OrderVersionPostageUpdateInputParameter { OrderVersionPostageID = 12345 }
+            };
+
+            var result = await service.OrderVersionPostageUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageUpdateResponse
+            {
+                OrderVersionPostageUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageUpdateAsync(It.IsAny<OrderVersionPostageUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageUpdateRequestBody
+            {
+                InputParameter = new OrderVersionPostageUpdateInputParameter { OrderVersionPostageID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageListResponse
+            {
+                OrderVersionPostageListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageListAsync(It.IsAny<OrderVersionPostageListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageListRequestBody
+            {
+                InputParameter = new OrderVersionPostageListInputParameter { VersionID = 12345 }
+            };
+
+            var result = await service.OrderVersionPostageListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageListResponse
+            {
+                OrderVersionPostageListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageListAsync(It.IsAny<OrderVersionPostageListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageListRequestBody
+            {
+                InputParameter = new OrderVersionPostageListInputParameter { VersionID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailInsertResponse
+            {
+                OrderVersionPostageDetailInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailInsertAsync(It.IsAny<OrderVersionPostageDetailInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailInsertRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailInputParameter()
+            };
+
+            var result = await service.OrderVersionPostageDetailInsertAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailInsertResponse
+            {
+                OrderVersionPostageDetailInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailInsertAsync(It.IsAny<OrderVersionPostageDetailInsertRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailInsertRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageDetailInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailListResponse
+            {
+                OrderVersionPostageDetailListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailListAsync(It.IsAny<OrderVersionPostageDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailListRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailListInputParameter { OrderVersionPostageID = 12345 }
+            };
+
+            var result = await service.OrderVersionPostageDetailListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailListResponse
+            {
+                OrderVersionPostageDetailListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailListAsync(It.IsAny<OrderVersionPostageDetailListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailListRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailListInputParameter { OrderVersionPostageID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageDetailListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailUpdateResponse
+            {
+                OrderVersionPostageDetailUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailUpdateAsync(It.IsAny<OrderVersionPostageDetailUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailUpdateRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailUpdateInputParameter { OrederVersionPostageDetailID = 12345 }
+            };
+
+            var result = await service.OrderVersionPostageDetailUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionPostageDetailUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionPostageDetailUpdateResponse
+            {
+                OrderVersionPostageDetailUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionPostageDetailUpdateAsync(It.IsAny<OrderVersionPostageDetailUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionPostageService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionPostageDetailUpdateRequestBody
+            {
+                InputParameter = new OrderVersionPostageDetailUpdateInputParameter { OrederVersionPostageDetailID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionPostageDetailUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/OrderVersionServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/OrderVersionServiceTests.cs
@@ -1,0 +1,309 @@
+using Midnight.SOAP.SDK.RequestObjects.OrderVersionInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class OrderVersionServiceTests
+    {
+        [Fact]
+        public async Task OrderVersionListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionListResponse
+            {
+                OrderVersionListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionListAsync(It.IsAny<OrderVersionListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionListRequestBody
+            {
+                InputParameter = new OrderVersionListInputParameter()
+            };
+
+            var result = await service.OrderVersionListAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionListResponse
+            {
+                OrderVersionListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionListAsync(It.IsAny<OrderVersionListRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionListRequestBody
+            {
+                InputParameter = new OrderVersionListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OrderVersionListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionQuickAddAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionQuickAddResponse
+            {
+                OrderVersionQuickAddResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionQuickAddAsync(It.IsAny<OrderVersionQuickAddRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionQuickAddRequestBody
+            {
+                OrderVersion = new OrderVersionQuickAddInputParameter { OrderNumber = "12345" }
+            };
+
+            var result = await service.OrderVersionQuickAddAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionQuickAddAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionQuickAddResponse
+            {
+                OrderVersionQuickAddResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionQuickAddAsync(It.IsAny<OrderVersionQuickAddRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionQuickAddRequestBody
+            {
+                OrderVersion = new OrderVersionQuickAddInputParameter { OrderNumber = "12345" }
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await service.OrderVersionQuickAddAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionUpdateResponse
+            {
+                OrderVersionUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionUpdateAsync(It.IsAny<OrderVersionUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionUpdateRequestBody
+            {
+                InputParameter = new OrderVersionUpdateInputParameter { VersionID = 12345 }
+            };
+
+            var result = await service.OrderVersionUpdateAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionUpdateResponse
+            {
+                OrderVersionUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionUpdateAsync(It.IsAny<OrderVersionUpdateRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionUpdateRequestBody
+            {
+                InputParameter = new OrderVersionUpdateInputParameter { VersionID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await service.OrderVersionUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionDeleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDeleteResponse
+            {
+                OrderVersionDeleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDeleteAsync(It.IsAny<OrderVersionDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDeleteInputParameter { VersionID = 12345 }
+            };
+
+            var result = await service.OrderVersionDeleteAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionDeleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionDeleteResponse
+            {
+                OrderVersionDeleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionDeleteAsync(It.IsAny<OrderVersionDeleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionDeleteRequestBody
+            {
+                InputParameter = new OrderVersionDeleteInputParameter { VersionID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await service.OrderVersionDeleteAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionNewResponse
+            {
+                OrderVersionNewResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionNewAsync(It.IsAny<OrderVersionNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionNewRequestBody
+            {
+                InputParameter = new OrderVersionNewInputParameter()
+            };
+
+            var result = await service.OrderVersionNewAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionNewResponse
+            {
+                OrderVersionNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionNewAsync(It.IsAny<OrderVersionNewRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionNewRequestBody
+            {
+                InputParameter = new OrderVersionNewInputParameter()
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await service.OrderVersionNewAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OrderVersionCompleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionCompleteResponse
+            {
+                OrderVersionCompleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionCompleteAsync(It.IsAny<OrderVersionCompleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionCompleteRequestBody
+            {
+                InputParameter = new OrderVersionCompleteInputParameter { Complete = true, VersionID = 12345 }
+            };
+
+            var result = await service.OrderVersionCompleteAsync(auth, request);
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OrderVersionCompleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionCompleteResponse
+            {
+                OrderVersionCompleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap
+                .Setup(s => s.OrderVersionCompleteAsync(It.IsAny<OrderVersionCompleteRequest>()))
+                .ReturnsAsync(response);
+
+            var service = new OrderVersionService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionCompleteRequestBody
+            {
+                InputParameter = new OrderVersionCompleteInputParameter { Complete = true, VersionID = 12345 }
+            };
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            {
+                await service.OrderVersionCompleteAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/ProofingServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/ProofingServiceTests.cs
@@ -1,0 +1,526 @@
+using Midnight.SOAP.SDK.RequestObjects.ProofingInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class ProofingServiceTests
+    {
+        [Fact]
+        public async Task RequestAttachmentListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestAttachmentListResponse
+            {
+                RequestAttachmentListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestAttachmentListAsync(It.IsAny<RequestAttachmentListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofAttachmentListRequestBody 
+            { 
+                InputParameter = new ProofAttachmentListInputParameter { RequestID = 1 }
+            };
+
+            var result = await service.RequestAttachmentListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestAttachmentListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestAttachmentListResponse
+            {
+                RequestAttachmentListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestAttachmentListAsync(It.IsAny<RequestAttachmentListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofAttachmentListRequestBody 
+            { 
+                InputParameter = new ProofAttachmentListInputParameter { RequestID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestAttachmentListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestApproverListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverListResponse
+            {
+                RequestApproverListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverListAsync(It.IsAny<RequestApproverListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverListRequestBody { InputParameter = new ProofApproverListInputParameter { RequestID = 1 } };
+
+            var result = await service.RequestApproverListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestApproverListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverListResponse
+            {
+                RequestApproverListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverListAsync(It.IsAny<RequestApproverListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverListRequestBody { InputParameter = new ProofApproverListInputParameter { RequestID = 1 } };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestApproverListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestStatusListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestStatusListResponse
+            {
+                RequestStatusListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestStatusListAsync(It.IsAny<RequestStatusListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofStatusListRequestBody { InputParameter = new ProofStatusListInputParameter() };
+
+            var result = await service.RequestStatusListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestStatusListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestStatusListResponse
+            {
+                RequestStatusListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestStatusListAsync(It.IsAny<RequestStatusListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofStatusListRequestBody { InputParameter = new ProofStatusListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestStatusListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestListResponse
+            {
+                RequestListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestListAsync(It.IsAny<RequestListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofListRequestBody 
+            { 
+                InputParameter = new ProofListInputParameter 
+                { 
+                    RequestDateFrom = "01/01/2025", RequestDateTo = "01/31/2025"
+                }
+            };
+
+            var result = await service.RequestListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestListResponse
+            {
+                RequestListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestListAsync(It.IsAny<RequestListRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofListRequestBody 
+            {
+                InputParameter = new ProofListInputParameter
+                {
+                    RequestDateFrom = "01/01/2025",
+                    RequestDateTo = "01/31/2025"
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestNewResponse
+            {
+                RequestNewResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestNewAsync(It.IsAny<RequestNewRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofNewRequestBody 
+            { 
+                InputParameter = new ProofNewInputParameter 
+                { 
+                    Requests = new List<RequestNew>
+                    {
+                        new RequestNew
+                        {
+                            RequestDate = "01/01/2025",
+                            CustomerID = 1,
+                        }
+                    }
+                }
+            };
+
+            var result = await service.RequestNewAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestNewResponse
+            {
+                RequestNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestNewAsync(It.IsAny<RequestNewRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofNewRequestBody 
+            { 
+                InputParameter = new ProofNewInputParameter 
+                { 
+                    Requests = new List<RequestNew>
+                    {
+                        new RequestNew
+                        {
+                            RequestDate = "01/01/2025",
+                            CustomerID = 1,
+                        }
+                    }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestNewAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestAddAttachmentAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestAddAttachmentResponse
+            {
+                RequestAddAttachmentResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestAddAttachmentAsync(It.IsAny<RequestAddAttachmentRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofAddAttachmentRequestBody 
+            { 
+                InputParameter = new ProofAddAttachmentInputParameter 
+                { 
+                    FileBytesBase64 = new byte(), FileName = "testfile.txt", RequestID = 1 
+                }
+            };
+
+            var result = await service.RequestAddAttachmentAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestAddAttachmentAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestAddAttachmentResponse
+            {
+                RequestAddAttachmentResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestAddAttachmentAsync(It.IsAny<RequestAddAttachmentRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofAddAttachmentRequestBody 
+            { 
+                InputParameter = new ProofAddAttachmentInputParameter 
+                { 
+                    FileBytesBase64 = new byte(), FileName = "testfile.txt", RequestID = 1 
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestAddAttachmentAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestApproverInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverInsertResponse
+            {
+                RequestApproverInsertResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverInsertAsync(It.IsAny<RequestApproverInsertRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverUpdateRequestBody 
+            { 
+                InputParameter = new ProofApproverUpdateInputParameter { RequestApproverID = 1 }
+            };
+
+            var result = await service.RequestApproverInsertAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestApproverInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverInsertResponse
+            {
+                RequestApproverInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverInsertAsync(It.IsAny<RequestApproverInsertRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverUpdateRequestBody 
+            { 
+                InputParameter = new ProofApproverUpdateInputParameter { RequestApproverID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestApproverInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestUpdateAsync_ReturnsResult_WhenNoErrors()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestUpdateResponse
+            {
+                RequestUpdateResult = "<Result><Results><Result><ReturnCode>0</ReturnCode></Result></Results></Result>"
+            };
+            mockSoap.Setup(s => s.RequestUpdateAsync(It.IsAny<RequestUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofUpdateRequestBody 
+            { 
+                InputParameter = new ProofUpdateInputParameter
+                {
+                    Requests = new List<ProofUpdate> { new ProofUpdate { RequestID = 1 } }
+                }
+            };
+
+            var result = await service.RequestUpdateAsync(auth, request);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task RequestUpdateAsync_ThrowsException_WhenErrorsExist()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestUpdateResponse
+            {
+                RequestUpdateResult = "<Result><Results><Result><ReturnCode>-1</ReturnCode><ReturnErrors><Error>Someerror</Error></ReturnErrors></Result></Results></Result>"
+            };
+            mockSoap.Setup(s => s.RequestUpdateAsync(It.IsAny<RequestUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            ProofUpdateRequestBody? request = null;
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () =>
+            {
+                await service.RequestUpdateAsync(auth, request!);
+            });
+
+            Assert.True(ex is Exception || ex is ArgumentNullException || ex is InvalidOperationException);
+        }
+
+        [Fact]
+        public async Task RequestApproverUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverUpdateResponse
+            {
+                RequestApproverUpdateResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverUpdateAsync(It.IsAny<RequestApproverUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverUpdateRequestBody 
+            { 
+                InputParameter = new ProofApproverUpdateInputParameter { RequestApproverID = 1 }
+            };
+
+            var result = await service.RequestApproverUpdateAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestApproverUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverUpdateResponse
+            {
+                RequestApproverUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverUpdateAsync(It.IsAny<RequestApproverUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverUpdateRequestBody 
+            { 
+                InputParameter = new ProofApproverUpdateInputParameter { RequestApproverID = 1 }            
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestApproverUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestDeleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestDeleteResponse
+            {
+                RequestDeleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestDeleteAsync(It.IsAny<RequestDeleteRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofDeleteRequestBody 
+            { 
+                InputParameter = new ProofDeleteInputParameter { RequestID = 1 }
+            };
+
+            var result = await service.RequestDeleteAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestDeleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestDeleteResponse
+            {
+                RequestDeleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestDeleteAsync(It.IsAny<RequestDeleteRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofDeleteRequestBody 
+            { 
+                InputParameter = new ProofDeleteInputParameter { RequestID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestDeleteAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task RequestApproverDeleteAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverDeleteResponse
+            {
+                RequestApproverDeleteResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverDeleteAsync(It.IsAny<RequestApproverDeleteRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverDeleteRequestBody 
+            { 
+                InputParameter = new ProofApproverDeleteInputParameter { RequestApproverID = 1 }
+            };
+
+            var result = await service.RequestApproverDeleteAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task RequestApproverDeleteAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RequestApproverDeleteResponse
+            {
+                RequestApproverDeleteResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.RequestApproverDeleteAsync(It.IsAny<RequestApproverDeleteRequest>())).ReturnsAsync(response);
+
+            var service = new ProofingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ProofApproverDeleteRequestBody 
+            { 
+                InputParameter = new ProofApproverDeleteInputParameter { RequestApproverID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.RequestApproverDeleteAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/PurchaseOrderServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/PurchaseOrderServiceTests.cs
@@ -1,0 +1,166 @@
+using Midnight.SOAP.SDK.RequestObjects.PurchaseOrderInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class PurchaseOrderServiceTests
+    {
+        [Fact]
+        public async Task PurchaseOrderNewAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderNewResponse
+            {
+                PurchaseOrderNewResult = "<Result><ReturnCode>0</ReturnCode><PurchaseOrderID>123</PurchaseOrderID></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderNewAsync(It.IsAny<PurchaseOrderNewRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderNewRequestBody
+            {
+                InputParameter = new PurchaseOrderNewInputParameter
+                {
+                    PurchaseOrders = new List<PurchaseOrderNew> {
+                        new PurchaseOrderNew { PurchaseOrderType = "PO", VendorID = 1 }
+                    }
+                }
+            };
+
+            var result = await service.PurchaseOrderNewAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+            Assert.Equal(123, result.PurchaseOrderID);
+        }
+
+        [Fact]
+        public async Task PurchaseOrderNewAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderNewResponse
+            {
+                PurchaseOrderNewResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderNewAsync(It.IsAny<PurchaseOrderNewRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderNewRequestBody
+            {
+                InputParameter = new PurchaseOrderNewInputParameter
+                {
+                    PurchaseOrders = new List<PurchaseOrderNew> {
+                        new PurchaseOrderNew { PurchaseOrderType = "PO", VendorID = 1 }
+                    }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.PurchaseOrderNewAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task PurchaseOrderListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderListResponse
+            {
+                PurchaseOrderListResult = "<Result><ReturnCode>0</ReturnCode><PurchaseOrders></PurchaseOrders></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderListAsync(It.IsAny<PurchaseOrderListRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderListRequestBody
+            {
+                InputParameter = new PurchaseOrderListInputParameter()
+            };
+
+            var result = await service.PurchaseOrderListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task PurchaseOrderListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderListResponse
+            {
+                PurchaseOrderListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderListAsync(It.IsAny<PurchaseOrderListRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderListRequestBody
+            {
+                InputParameter = new PurchaseOrderListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.PurchaseOrderListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task PurchaseOrderUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderUpdateResponse
+            {
+                PurchaseOrderUpdateResult = "<Result><ReturnCode>0</ReturnCode><PurchaseOrderID>456</PurchaseOrderID></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderUpdateAsync(It.IsAny<PurchaseOrderUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderUpdateRequestBody
+            {
+                InputParameter = new PurchaseOrderUpdateInputParameter
+                {
+                    PurchaseOrder = new List<PurchaseOrderUpdateInput> {
+                        new PurchaseOrderUpdateInput { PurchaseOrderID = 1, VendorID = 2 }
+                    }
+                }
+            };
+
+            var result = await service.PurchaseOrderUpdateAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+            Assert.Equal(456, result.PurchaseOrderID);
+        }
+
+        [Fact]
+        public async Task PurchaseOrderUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PurchaseOrderUpdateResponse
+            {
+                PurchaseOrderUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.PurchaseOrderUpdateAsync(It.IsAny<PurchaseOrderUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new PurchaseOrderService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PurchaseOrderUpdateRequestBody
+            {
+                InputParameter = new PurchaseOrderUpdateInputParameter
+                {
+                    PurchaseOrder = new List<PurchaseOrderUpdateInput> {
+                        new PurchaseOrderUpdateInput { PurchaseOrderID = 1, VendorID = 2 }
+                    }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.PurchaseOrderUpdateAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/SettingServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/SettingServiceTests.cs
@@ -1,0 +1,804 @@
+using Midnight.SOAP.SDK.RequestObjects.SettingInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class SettingServiceTests
+    {
+        [Fact]
+        public async Task CompanyListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CompanyListResponse
+            {
+                CompanyListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.CompanyListAsync(It.IsAny<CompanyListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CompanyListRequestBody { InputParameter = new CompanyListInputParameter() };
+
+            var result = await service.CompanyListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task CompanyListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CompanyListResponse
+            {
+                CompanyListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.CompanyListAsync(It.IsAny<CompanyListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CompanyListRequestBody { InputParameter = new CompanyListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.CompanyListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task OperationListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OperationListResponse
+            {
+                OperationListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.OperationListAsync(It.IsAny<OperationListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OperationListRequestBody { Active = true };
+
+            var result = await service.OperationListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task OperationListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OperationListResponse
+            {
+                OperationListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.OperationListAsync(It.IsAny<OperationListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OperationListRequestBody { Active = true };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.OperationListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task JobFrequencyListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobFrequencyListResponse
+            {
+                JobFrequencyListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.JobFrequencyListAsync(It.IsAny<JobFrequencyListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobFrequencyListRequestBody { InputParameter = new JobFrequencyListInputParameter() };
+
+            var result = await service.JobFrequencyListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task JobFrequencyListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobFrequencyListResponse
+            {
+                JobFrequencyListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.JobFrequencyListAsync(It.IsAny<JobFrequencyListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobFrequencyListRequestBody { InputParameter = new JobFrequencyListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.JobFrequencyListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task MailClassListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailClassListResponse
+            {
+                MailClassListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.MailClassListAsync(It.IsAny<MailClassListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailClassListRequestBody { InputParameter = new MailClassListInputParameter() };
+
+            var result = await service.MailClassListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task MailClassListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailClassListResponse
+            {
+                MailClassListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.MailClassListAsync(It.IsAny<MailClassListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailClassListRequestBody { InputParameter = new MailClassListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.MailClassListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task MailCategoryListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailCategoryListResponse
+            {
+                MailCategoryListResult = "<Result><ReturnCode>0</ReturnCode></Result>"
+            };
+            mockSoap.Setup(s => s.MailCategoryListAsync(It.IsAny<MailCategoryListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailCategoryListRequestBody { InputParameter = new MailCategoryListInputParameter() };
+
+            var result = await service.MailCategoryListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task MailCategoryListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailCategoryListResponse
+            {
+                MailCategoryListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.MailCategoryListAsync(It.IsAny<MailCategoryListRequest>())).ReturnsAsync(response);
+
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailCategoryListRequestBody { InputParameter = new MailCategoryListInputParameter() };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.MailCategoryListAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task ContactTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ContactTypeListResponse { ContactTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.ContactTypeListAsync(It.IsAny<ContactTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ContactTypeListRequestBody { InputParameter = new ContactTypeListInputParameter() };
+            var result = await service.ContactTypeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task ContactTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ContactTypeListResponse { ContactTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.ContactTypeListAsync(It.IsAny<ContactTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ContactTypeListRequestBody { InputParameter = new ContactTypeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.ContactTypeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task WarehouseLocationListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WarehouseLocationListResponse { WarehouseLocationListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.WarehouseLocationListAsync(It.IsAny<WarehouseLocationListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WarehouseLocationListRequestBody { InputParameter = new WarehouseLocationListInputParameter() };
+            var result = await service.WarehouseLocationListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task WarehouseLocationListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WarehouseLocationListResponse { WarehouseLocationListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.WarehouseLocationListAsync(It.IsAny<WarehouseLocationListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WarehouseLocationListRequestBody { InputParameter = new WarehouseLocationListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.WarehouseLocationListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task WarehouseListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WarehouseListResponse { WarehouseListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.WarehouseListAsync(It.IsAny<WarehouseListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WarehouseListRequestBody { InputParameter = new WarehouseListInputParameter() };
+            var result = await service.WarehouseListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task WarehouseListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new WarehouseListResponse { WarehouseListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.WarehouseListAsync(It.IsAny<WarehouseListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new WarehouseListRequestBody { InputParameter = new WarehouseListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.WarehouseListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task TermsListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new TermsListResponse { TermsListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.TermsListAsync(It.IsAny<TermsListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new TermsListRequestBody { InputParameter = new TermsListInputParameter() };
+            var result = await service.TermsListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task TermsListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new TermsListResponse { TermsListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.TermsListAsync(It.IsAny<TermsListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new TermsListRequestBody { InputParameter = new TermsListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.TermsListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task ServiceWizardListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ServiceWizardListResponse { ServiceWizardListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.ServiceWizardListAsync(It.IsAny<ServiceWizardListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceWizardListRequestBody();
+            var result = await service.ServiceWizardListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task ServiceWizardListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ServiceWizardListResponse { ServiceWizardListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.ServiceWizardListAsync(It.IsAny<ServiceWizardListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceWizardListRequestBody();
+            await Assert.ThrowsAsync<Exception>(async () => { await service.ServiceWizardListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task CustomerTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerTypeListResponse { CustomerTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.CustomerTypeListAsync(It.IsAny<CustomerTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerTypeListRequestBody { InputParameter = new CustomerTypeListInputParameter() };
+            var result = await service.CustomerTypeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task CustomerTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new CustomerTypeListResponse { CustomerTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.CustomerTypeListAsync(It.IsAny<CustomerTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new CustomerTypeListRequestBody { InputParameter = new CustomerTypeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.CustomerTypeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task DeliveryMethodListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DeliveryMethodListResponse { DeliveryMethodListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.DeliveryMethodListAsync(It.IsAny<DeliveryMethodListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DeliveryMethodListRequestBody { InputParameter = new DeliveryMethodListInputParameter() };
+            var result = await service.DeliveryMethodListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task DeliveryMethodListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DeliveryMethodListResponse { DeliveryMethodListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.DeliveryMethodListAsync(It.IsAny<DeliveryMethodListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DeliveryMethodListRequestBody { InputParameter = new DeliveryMethodListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.DeliveryMethodListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task DocumentTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DocumentTypeListResponse { DocumentTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.DocumentTypeListAsync(It.IsAny<DocumentTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DocumentTypeListRequestBody { InputParameter = new DocumentTypeListInputParameter() };
+            var result = await service.DocumentTypeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task DocumentTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new DocumentTypeListResponse { DocumentTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.DocumentTypeListAsync(It.IsAny<DocumentTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new DocumentTypeListRequestBody { InputParameter = new DocumentTypeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.DocumentTypeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task EmployeeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EmployeeListResponse { EmployeeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.EmployeeListAsync(It.IsAny<EmployeeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EmployeeListRequestBody { InputParameter = new EmployeeListInputParameter() };
+            var result = await service.EmployeeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task EmployeeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new EmployeeListResponse { EmployeeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.EmployeeListAsync(It.IsAny<EmployeeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new EmployeeListRequestBody { InputParameter = new EmployeeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.EmployeeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task JobPriorityListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobPriorityListResponse { JobPriorityListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.JobPriorityListAsync(It.IsAny<JobPriorityListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobPriorityListRequestBody { InputParameter = new JobPriorityListInputParameter() };
+            var result = await service.JobPriorityListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task JobPriorityListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobPriorityListResponse { JobPriorityListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.JobPriorityListAsync(It.IsAny<JobPriorityListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobPriorityListRequestBody { InputParameter = new JobPriorityListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.JobPriorityListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task JobProgressListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobProgressListResponse { JobProgressListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.JobProgressListAsync(It.IsAny<JobProgressListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobProgressListRequestBody { InputParameter = new JobProgressListInputParameter() };
+            var result = await service.JobProgressListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task JobProgressListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobProgressListResponse { JobProgressListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.JobProgressListAsync(It.IsAny<JobProgressListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobProgressListRequestBody { InputParameter = new JobProgressListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.JobProgressListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task JobTypeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobTypeListResponse { JobTypeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.JobTypeListAsync(It.IsAny<JobTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobTypeListRequestBody { InputParameter = new JobTypeListInputParameter() };
+            var result = await service.JobTypeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task JobTypeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new JobTypeListResponse { JobTypeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.JobTypeListAsync(It.IsAny<JobTypeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new JobTypeListRequestBody { InputParameter = new JobTypeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.JobTypeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task MailGeographyListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailGeographyListResponse { MailGeographyListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.MailGeographyListAsync(It.IsAny<MailGeographyListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailGeographyListRequestBody { InputParameter = new MailGeographyListInputParameter() };
+            var result = await service.MailGeographyListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task MailGeographyListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailGeographyListResponse { MailGeographyListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.MailGeographyListAsync(It.IsAny<MailGeographyListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailGeographyListRequestBody { InputParameter = new MailGeographyListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.MailGeographyListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task MailSortListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailSortListResponse { MailSortListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.MailSortListAsync(It.IsAny<MailSortListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailSortListRequestBody { InputParameter = new MailSortListInputParameter() };
+            var result = await service.MailSortListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task MailSortListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new MailSortListResponse { MailSortListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.MailSortListAsync(It.IsAny<MailSortListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new MailSortListRequestBody { InputParameter = new MailSortListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.MailSortListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task PostOfficeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostOfficeListResponse { PostOfficeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.PostOfficeListAsync(It.IsAny<PostOfficeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostOfficeListRequestBody { InputParameter = new PostOfficeListInputParameter() };
+            var result = await service.PostOfficeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task PostOfficeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostOfficeListResponse { PostOfficeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.PostOfficeListAsync(It.IsAny<PostOfficeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostOfficeListRequestBody { InputParameter = new PostOfficeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.PostOfficeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task PostageAffixListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostageAffixListResponse { PostageAffixListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.PostageAffixListAsync(It.IsAny<PostageAffixListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostageAffixListRequestBody { InputParameter = new PostageAffixListInputParameter() };
+            var result = await service.PostageAffixListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task PostageAffixListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostageAffixListResponse { PostageAffixListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.PostageAffixListAsync(It.IsAny<PostageAffixListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostageAffixListRequestBody { InputParameter = new PostageAffixListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.PostageAffixListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task PostageStatusListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostageStatusListResponse { PostageStatusListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.PostageStatusListAsync(It.IsAny<PostageStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostageStatusListRequestBody { InputParameter = new PostageStatusListInputParameter() };
+            var result = await service.PostageStatusListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task PostageStatusListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new PostageStatusListResponse { PostageStatusListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.PostageStatusListAsync(It.IsAny<PostageStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new PostageStatusListRequestBody { InputParameter = new PostageStatusListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.PostageStatusListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task ReasonCodeListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ReasonCodeListResponse { ReasonCodeListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.ReasonCodeListAsync(It.IsAny<ReasonCodeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ReasonCodeListRequestBody { InputParameter = new ReasonCodeListInputParameter() };
+            var result = await service.ReasonCodeListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task ReasonCodeListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ReasonCodeListResponse { ReasonCodeListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.ReasonCodeListAsync(It.IsAny<ReasonCodeListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ReasonCodeListRequestBody { InputParameter = new ReasonCodeListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.ReasonCodeListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task RecordResolutionListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RecordResolutionListResponse { RecordResolutionListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.RecordResolutionListAsync(It.IsAny<RecordResolutionListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new RecordResolutionListRequestBody { InputParameter = new RecordResolutionListInputParameter() };
+            var result = await service.RecordResolutionListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task RecordResolutionListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new RecordResolutionListResponse { RecordResolutionListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.RecordResolutionListAsync(It.IsAny<RecordResolutionListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new RecordResolutionListRequestBody { InputParameter = new RecordResolutionListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.RecordResolutionListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task ResidualInstructionListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ResidualInstructionListResponse { ResidualInstructionListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.ResidualInstructionListAsync(It.IsAny<ResidualInstructionListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ResidualInstructionListRequestBody { InputParameter = new ResidualInstructionListInputParameter() };
+            var result = await service.ResidualInstructionListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task ResidualInstructionListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ResidualInstructionListResponse { ResidualInstructionListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.ResidualInstructionListAsync(It.IsAny<ResidualInstructionListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ResidualInstructionListRequestBody { InputParameter = new ResidualInstructionListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.ResidualInstructionListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task ServiceListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ServiceListResponse { ServiceListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.ServiceListAsync(It.IsAny<ServiceListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceListRequestBody { InputParameter = new ServiceListInputParameter() };
+            var result = await service.ServiceListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task ServiceListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new ServiceListResponse { ServiceListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.ServiceListAsync(It.IsAny<ServiceListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new ServiceListRequestBody { InputParameter = new ServiceListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.ServiceListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task UnitMeasureListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new UnitMeasureListResponse { UnitMeasureListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.UnitMeasureListAsync(It.IsAny<UnitMeasureListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new UnitMeasureListRequestBody { InputParameter = new UnitMeasureListInputParameter() };
+            var result = await service.UnitMeasureListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task UnitMeasureListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new UnitMeasureListResponse { UnitMeasureListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.UnitMeasureListAsync(It.IsAny<UnitMeasureListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new UnitMeasureListRequestBody { InputParameter = new UnitMeasureListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.UnitMeasureListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task OrderStatusListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderStatusListResponse { OrderStatusListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.OrderStatusListAsync(It.IsAny<OrderStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderStatusListRequestBody { InputParameter = new OrderStatusListInputParameter() };
+            var result = await service.OrderStatusListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task OrderStatusListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderStatusListResponse { OrderStatusListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.OrderStatusListAsync(It.IsAny<OrderStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderStatusListRequestBody { InputParameter = new OrderStatusListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.OrderStatusListAsync(auth, request); });
+        }
+
+        [Fact]
+        public async Task OrderVersionStatusListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionStatusListResponse { OrderVersionStatusListResult = "<Result><ReturnCode>0</ReturnCode></Result>" };
+            mockSoap.Setup(s => s.OrderVersionStatusListAsync(It.IsAny<OrderVersionStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionStatusListRequestBody { InputParameter = new OrderVersionStatusListInputParameter() };
+            var result = await service.OrderVersionStatusListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+        [Fact]
+        public async Task OrderVersionStatusListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new OrderVersionStatusListResponse { OrderVersionStatusListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>" };
+            mockSoap.Setup(s => s.OrderVersionStatusListAsync(It.IsAny<OrderVersionStatusListRequest>())).ReturnsAsync(response);
+            var service = new SettingService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new OrderVersionStatusListRequestBody { InputParameter = new OrderVersionStatusListInputParameter() };
+            await Assert.ThrowsAsync<Exception>(async () => { await service.OrderVersionStatusListAsync(auth, request); });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/VendorContactServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/VendorContactServiceTests.cs
@@ -1,0 +1,159 @@
+using Midnight.SOAP.SDK.RequestObjects.VendorContactInputs;
+using Midnight.SOAP.SDK.ResponseObjects.VendorContactOutputs;
+using MidnightAPI;
+using Moq;
+using Xunit;
+using System.Collections.Generic;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class VendorContactServiceTests
+    {
+        [Fact]
+        public async Task VendorContactInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactInsertResponse
+            {
+                VendorContactInsertResult = "<Result><ReturnCode>0</ReturnCode><VendorContacts></VendorContacts></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactInsertAsync(It.IsAny<VendorContactInsertRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactInsertRequestBody
+            {
+                InputParameter = new VendorContactInsertInputParameter
+                {
+                    VendorContacts = new List<VendorContactInsert> 
+                    {
+                        new VendorContactInsert { VendorID = 1, FirstName = "John", LastName = "Doe", Active = true }
+                    }
+                }
+            };
+
+            var result = await service.VendorContactInsertAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task VendorContactInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactInsertResponse
+            {
+                VendorContactInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactInsertAsync(It.IsAny<VendorContactInsertRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactInsertRequestBody
+            {
+                InputParameter = new VendorContactInsertInputParameter
+                {
+                    VendorContacts = new List<VendorContactInsert> 
+                    {
+                        new VendorContactInsert { VendorID = 1, FirstName = "John", LastName = "Doe", Active = true }
+                    }
+                }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorContactInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task VendorContactUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactUpdateResponse
+            {
+                VendorContactUpdateResult = "<Result><ReturnCode>0</ReturnCode><VendorContacts></VendorContacts></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactUpdateAsync(It.IsAny<VendorContactUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactUpdateRequestBody
+            {
+                VendorContact = new VendorContactUpdateInputParameter { ContactID = 1, VendorID = 1 }
+            };
+
+            var result = await service.VendorContactUpdateAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task VendorContactUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactUpdateResponse
+            {
+                VendorContactUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactUpdateAsync(It.IsAny<VendorContactUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactUpdateRequestBody
+            {
+                VendorContact = new VendorContactUpdateInputParameter { ContactID = 1, VendorID = 1 }
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorContactUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task VendorContactListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactListResponse
+            {
+                VendorContactListResult = "<Result><ReturnCode>0</ReturnCode><VendorContacts></VendorContacts></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactListAsync(It.IsAny<VendorContactListRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactListRequestBody
+            {
+                InputParameter = new VendorContactListInputParameter()
+            };
+
+            var result = await service.VendorContactListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task VendorContactListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorContactListResponse
+            {
+                VendorContactListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorContactListAsync(It.IsAny<VendorContactListRequest>())).ReturnsAsync(response);
+
+            var service = new VendorContactService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorContactListRequestBody
+            {
+                InputParameter = new VendorContactListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorContactListAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.Tests/VendorServiceTests.cs
+++ b/Midnight.SOAP.SDK.Tests/VendorServiceTests.cs
@@ -1,0 +1,134 @@
+using Midnight.SOAP.SDK.RequestObjects.VendorInputs;
+using MidnightAPI;
+using Moq;
+
+namespace Midnight.SOAP.SDK.Tests
+{
+    public class VendorServiceTests
+    {
+        [Fact]
+        public async Task VendorInsertAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorInsertResponse
+            {
+                VendorInsertResult = "<Result><ReturnCode>0</ReturnCode><VendorID>123</VendorID></Result>"
+            };
+            mockSoap.Setup(s => s.VendorInsertAsync(It.IsAny<VendorInsertRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorInsertRequestBody { VendorName = "Test Vendor" };
+
+            var result = await service.VendorInsertAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+            Assert.Equal(123, result.VendorID);
+        }
+
+        [Fact]
+        public async Task VendorInsertAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorInsertResponse
+            {
+                VendorInsertResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorInsertAsync(It.IsAny<VendorInsertRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorInsertRequestBody { VendorName = "Test Vendor" };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorInsertAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task VendorUpdateAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorUpdateResponse
+            {
+                VendorUpdateResult = "<Result><ReturnCode>0</ReturnCode><VendorID>456</VendorID></Result>"
+            };
+            mockSoap.Setup(s => s.VendorUpdateAsync(It.IsAny<VendorUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorUpdateRequestBody { VendorID = 456, VendorName = "Updated Vendor" };
+
+            var result = await service.VendorUpdateAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+            Assert.Equal(456, result.VendorID);
+        }
+
+        [Fact]
+        public async Task VendorUpdateAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorUpdateResponse
+            {
+                VendorUpdateResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorUpdateAsync(It.IsAny<VendorUpdateRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorUpdateRequestBody { VendorID = 456, VendorName = "Updated Vendor" };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorUpdateAsync(auth, request);
+            });
+        }
+
+        [Fact]
+        public async Task VendorListAsync_ReturnsResult_WhenSuccess()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorListResponse
+            {
+                VendorListResult = "<Result><ReturnCode>0</ReturnCode><Vendors></Vendors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorListAsync(It.IsAny<VendorListRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorListRequestBody
+            {
+                InputParameter = new VendorListInputParameter()
+            };
+
+            var result = await service.VendorListAsync(auth, request);
+            Assert.NotNull(result);
+            Assert.Equal(0, result.ReturnCode);
+        }
+
+        [Fact]
+        public async Task VendorListAsync_ThrowsException_WhenReturnCodeIsNotZero()
+        {
+            var mockSoap = new Mock<Service1Soap>();
+            var response = new VendorListResponse
+            {
+                VendorListResult = "<Result><ReturnCode>1</ReturnCode><ReturnErrors><Error>Some error</Error></ReturnErrors></Result>"
+            };
+            mockSoap.Setup(s => s.VendorListAsync(It.IsAny<VendorListRequest>())).ReturnsAsync(response);
+
+            var service = new VendorService(mockSoap.Object);
+            var auth = new ValidationSoapHeader { DevToken = "test-token" };
+            var request = new VendorListRequestBody
+            {
+                InputParameter = new VendorListInputParameter()
+            };
+
+            await Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await service.VendorListAsync(auth, request);
+            });
+        }
+    }
+}

--- a/Midnight.SOAP.SDK.sln
+++ b/Midnight.SOAP.SDK.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.14.36301.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Midnight.SOAP.SDK", "Midnight.SOAP.SDK\Midnight.SOAP.SDK.csproj", "{D59F3677-9343-4E7F-9D2B-A7C58B33991C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Midnight.SOAP.SDK.Tests", "Midnight.SOAP.SDK.Tests\Midnight.SOAP.SDK.Tests.csproj", "{1A82C1B8-5C84-4B40-B8D9-1E92195733A9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{D59F3677-9343-4E7F-9D2B-A7C58B33991C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D59F3677-9343-4E7F-9D2B-A7C58B33991C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D59F3677-9343-4E7F-9D2B-A7C58B33991C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A82C1B8-5C84-4B40-B8D9-1E92195733A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A82C1B8-5C84-4B40-B8D9-1E92195733A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A82C1B8-5C84-4B40-B8D9-1E92195733A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A82C1B8-5C84-4B40-B8D9-1E92195733A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Midnight.SOAP.SDK/AuthenticationService.cs
+++ b/Midnight.SOAP.SDK/AuthenticationService.cs
@@ -4,21 +4,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for authenticating clients and interacting with the Midnight SOAP API.
+/// Provides methods for authenticating clients and managing authentication-related operations. 
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="AuthenticationService"/> class is designed to facilitate client authentication  using
-/// developer tokens and to interact with the Midnight SOAP API. It provides an asynchronous  method for obtaining
-/// authentication headers required for API requests. Ensure that the developer  token used for authentication is valid
-/// and properly configured.</remarks>
-public class AuthenticationService
+/// <remarks>The <see cref="AuthenticationService"/> class is designed to handle client authentication using a
+/// developer token. It interacts with the underlying SOAP service to retrieve necessary information, such as the web
+/// service version, and returns authentication headers required for subsequent API calls. Ensure that the provided
+/// developer token is valid before using this service.</remarks>
+/// <param name="_soap"></param>
+public class AuthenticationService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1SoapClient _soap;
-    public AuthenticationService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Authenticates the client using the provided developer token and returns a validation header.

--- a/Midnight.SOAP.SDK/CustomerContactService.cs
+++ b/Midnight.SOAP.SDK/CustomerContactService.cs
@@ -7,21 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with customer contact information via SOAP requests.
+/// Provides methods for managing customer contact information through SOAP-based operations.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="CustomerContactService"/> class enables asynchronous operations for inserting,
-/// retrieving,  and updating customer contact information. Each method requires valid authentication credentials and 
-/// properly formatted request objects. This class is designed to handle SOAP-based communication with  external
-/// services, converting request objects to XML and parsing responses.</remarks>
-public class CustomerContactService
+/// <remarks>This service facilitates the insertion, retrieval, and updating of customer contact information  by
+/// interacting with a SOAP-based backend. Each operation logs request and response details for  debugging purposes and
+/// throws exceptions for error conditions, such as invalid input or failed  operations. Ensure that sensitive
+/// information is handled appropriately in logs.</remarks>
+/// <param name="_soap"></param>
+public class CustomerContactService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public CustomerContactService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to insert customer contact information and returns the result of the operation.
@@ -180,3 +175,4 @@ public class CustomerContactService
     }
 
 }
+

--- a/Midnight.SOAP.SDK/CustomerService.cs
+++ b/Midnight.SOAP.SDK/CustomerService.cs
@@ -7,22 +7,19 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with customer data through SOAP-based web services.
+/// Provides methods for interacting with customer-related data and operations through a SOAP service.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="CustomerService"/> class facilitates operations such as retrieving customer lists and
-/// updating customer information by sending SOAP requests to a configured endpoint. This class requires valid
-/// authentication headers and properly formatted request objects for its methods. It is designed to handle asynchronous
-/// operations and return structured responses.</remarks>
-public class CustomerService
+/// <remarks>The <see cref="CustomerService"/> class acts as a client for a SOAP-based API, enabling operations
+/// such as retrieving customer data,  updating customer information, and managing customer-related entities like
+/// postage accounts, registration IDs, and permit numbers.  Each method in this class sends a SOAP request, processes
+/// the response, and returns the result in a strongly-typed object. <para> This class requires an instance of <see
+/// cref="Service1Soap"/> to be provided during initialization, which is used to send SOAP requests. </para> <para>
+/// Exceptions are thrown for invalid input parameters or if the SOAP service returns an error. Ensure that all required
+/// parameters are  properly populated and that the authentication header contains valid credentials. </para></remarks>
+/// <param name="_soap"></param>
+public class CustomerService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public CustomerService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     ///GetCustomerOrders
     ///GetOrderVersions

--- a/Midnight.SOAP.SDK/DJBService.cs
+++ b/Midnight.SOAP.SDK/DJBService.cs
@@ -8,23 +8,17 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with the DJB SOAP service, including retrieving job statuses, fetching DJB lists,
-/// and updating DJB statuses.
+/// Provides methods for interacting with the DJB SOAP service, including operations for retrieving job statuses,
+/// fetching DJB lists, and updating DJB statuses. IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This class acts as a client for the DJB SOAP service, encapsulating the logic for sending requests
-/// and processing responses. It includes methods for common operations such as querying job statuses, retrieving DJB
-/// lists, and updating DJB statuses. Each method handles serialization and deserialization of request and response
-/// objects, as well as error handling for non-zero return codes. <para> Ensure that valid authentication credentials
-/// are provided when calling any method in this class. </para></remarks>
-public class DJBService
+/// <remarks>This class acts as a client for the DJB SOAP service, enabling the execution of various operations
+/// such as querying job statuses, retrieving DJB lists, and updating DJB statuses. Each method sends a SOAP request to
+/// the corresponding endpoint, processes the response, and returns the result as a strongly-typed object.  Exceptions
+/// are thrown for any errors encountered during the SOAP request or if the response indicates a failure. Ensure that
+/// valid authentication headers and properly populated request objects are provided when calling the methods.</remarks>
+/// <param name="_soap"></param>
+public class DJBService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public DJBService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to retrieve the status of DJB jobs and returns the result.

--- a/Midnight.SOAP.SDK/EstimateService.cs
+++ b/Midnight.SOAP.SDK/EstimateService.cs
@@ -8,22 +8,15 @@ namespace Midnight.SOAP.SDK;
 
 /// <summary>
 /// Provides methods for interacting with a SOAP service to manage estimates and related operations.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
 /// <remarks>The <see cref="EstimateService"/> class offers a set of asynchronous methods to perform various
 /// operations such as retrieving estimates, inserting new estimates, updating existing estimates, and calculating
 /// preview prices. Each method communicates with the SOAP service by serializing request objects to XML and
 /// deserializing the responses into strongly-typed result objects. Exceptions are thrown for invalid inputs or if the
 /// SOAP service returns an error.</remarks>
-public class EstimateService
+public class EstimateService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public EstimateService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     /// <summary>
     /// Sends a SOAP request to retrieve a list of estimates and returns the result.

--- a/Midnight.SOAP.SDK/InventoryItemService.cs
+++ b/Midnight.SOAP.SDK/InventoryItemService.cs
@@ -7,22 +7,17 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with inventory item data through SOAP-based services.
+/// Provides methods for interacting with inventory item data through SOAP-based service.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="InventoryItemService"/> class serves as a client for performing various operations
-/// related to inventory items,  such as retrieving item locations, lots, transaction types, and types, as well as
-/// creating and updating inventory item lots.  Each method sends a SOAP request to the corresponding service endpoint
-/// and processes the response.  Exceptions are thrown for failed operations, and detailed error information is logged
-/// for debugging purposes.</remarks>
-public class InventoryItemService
+/// <remarks>The <see cref="InventoryItemService"/> class offers a set of asynchronous methods to retrieve,
+/// create, update,  and manage inventory item data, including locations, lots, transaction types, and item types. Each
+/// method  communicates with a SOAP service, serializing request objects to XML and deserializing responses into 
+/// strongly-typed result objects. Exceptions are thrown for non-zero return codes or SOAP request failures,  and
+/// detailed logging is performed for debugging purposes.</remarks>
+/// <param name="_soap"></param>
+public class InventoryItemService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public InventoryItemService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Retrieves a list of inventory item locations based on the provided request parameters.

--- a/Midnight.SOAP.SDK/InventoryService.cs
+++ b/Midnight.SOAP.SDK/InventoryService.cs
@@ -8,23 +8,29 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with inventory data through SOAP-based web services.
+/// Provides methods for interacting with an external SOAP service to manage inventory operations.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="InventoryService"/> class facilitates operations such as retrieving inventory lists, 
-/// updating inventory details, and querying inventory item locations, lots, and transactions.  Each method sends a SOAP
-/// request to the underlying service and processes the response accordingly. Ensure that valid authentication
-/// credentials are provided for all operations.</remarks>
-public class InventoryService
+/// <remarks>The <see cref="InventoryService"/> class facilitates communication with a SOAP-based service to
+/// perform various inventory-related operations, such as retrieving inventory data, updating inventory details,
+/// creating new inventory entries, and managing item requests. Each method in this class sends a SOAP request and
+/// processes the response, throwing exceptions for errors encountered during the operation.  This class requires a
+/// valid instance of <see cref="Service1Soap"/> to be provided during initialization, which is used to send SOAP
+/// requests. Ensure that the provided SOAP service is properly configured and accessible.</remarks>
+/// <param name="_soap"></param>
+public class InventoryService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public InventoryService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
-    
+    /// <summary>
+    /// Sends a SOAP request to retrieve inventory data and returns the result.
+    /// </summary>
+    /// <remarks>This method communicates with a SOAP service to retrieve inventory information based on the
+    /// provided request parameters. If the SOAP service returns an error, an exception is thrown with details about the
+    /// failure.</remarks>
+    /// <param name="auth">The authentication header containing credentials required for the SOAP request.</param>
+    /// <param name="request">The request body containing parameters for the inventory query.</param>
+    /// <returns>An <see cref="InventoryListResult"/> object containing the inventory data and any associated metadata.</returns>
+    /// <exception cref="Exception">Thrown if the SOAP service returns an error or if an unexpected exception occurs during the request.</exception>
     public async Task<InventoryListResult> InventoryListAsync(ValidationSoapHeader auth, InventoryListRequestBody request)
     {
 

--- a/Midnight.SOAP.SDK/JobCostingService.cs
+++ b/Midnight.SOAP.SDK/JobCostingService.cs
@@ -7,26 +7,21 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with the Job Costing SOAP service, including operations for job costing, production
-/// time entries, service time entries, and other job cost-related functionalities.
+/// Provides methods for interacting with the Job Costing SOAP service, including operations for job costing, 
+/// production time entries, service time entries, and other job cost updates.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service acts as a client for the Job Costing SOAP API, enabling the execution of various job
-/// costing operations. Each method in this class sends a SOAP request, processes the response, and returns the result
-/// in a strongly-typed object. Exceptions are thrown for errors such as invalid input, SOAP request failures, or
-/// non-zero return codes from the service. <para> The methods in this class are asynchronous and should be awaited to
-/// ensure proper execution. Callers must provide valid authentication credentials via the <see
-/// cref="ValidationSoapHeader"/> parameter for all operations. </para> <para> Logging is performed for debugging
-/// purposes, including request and response data. Ensure that sensitive information is handled appropriately in the
-/// logs. </para></remarks>
-public class JobCostingService
+/// <remarks>This service acts as a client for the Job Costing SOAP API, enabling various job costing operations
+/// such as  creating, updating, and retrieving job cost details. Each method in this class sends a SOAP request,
+/// processes  the response, and returns the result as a strongly-typed object. Exceptions are thrown for errors such as
+/// invalid input, SOAP request failures, or non-zero return codes from the service. <para> Logging is performed for
+/// debugging purposes, including request and response data. Ensure that sensitive  information is handled appropriately
+/// in the logs. </para> <para> Callers must provide valid authentication credentials via the <see
+/// cref="ValidationSoapHeader"/> parameter  for all methods. Additionally, input parameters must meet the specified
+/// requirements (e.g., non-null values)  to avoid exceptions. </para></remarks>
+/// <param name="_soap"></param>
+public class JobCostingService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public JobCostingService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to perform a "Job Out" operation and processes the response.

--- a/Midnight.SOAP.SDK/Midnight.SOAP.SDK.csproj
+++ b/Midnight.SOAP.SDK/Midnight.SOAP.SDK.csproj
@@ -14,7 +14,13 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Copyright>Copyright (c) MidnightMeshLLC 2025</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
-    <Version>1.0.0</Version>
+    <Version>1.0.4</Version>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <Optimize>False</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\LICENSE.txt">

--- a/Midnight.SOAP.SDK/OrderService.cs
+++ b/Midnight.SOAP.SDK/OrderService.cs
@@ -1,5 +1,4 @@
-﻿using DocumentFormat.OpenXml.Office2016.Excel;
-using Midnight.SOAP.SDK.RequestObjects.OrderInputs;
+﻿using Midnight.SOAP.SDK.RequestObjects.OrderInputs;
 using Midnight.SOAP.SDK.ResponseObjects.OrderOutputs;
 using Midnight.SOAP.SDK.Utilities;
 using MidnightAPI;
@@ -8,22 +7,20 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with orders via SOAP-based web services.
+/// Provides methods for interacting with orders through a SOAP-based service.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>The <see cref="OrderService"/> class facilitates operations such as retrieving, adding, and updating
-/// orders by sending SOAP requests to a remote service. Each method in this class requires authentication credentials
-/// and properly formatted request objects. This class is designed for asynchronous operations and ensures that
-/// responses are parsed into appropriate models for further processing.</remarks>
-public class OrderService
+/// <remarks>The <see cref="OrderService"/> class offers a set of asynchronous methods to manage orders, including
+/// retrieving, creating, updating, and attaching files to orders. Each method communicates with a SOAP service, sending
+/// requests and processing responses. Ensure that valid authentication credentials are provided for all operations.
+/// <para> This class is designed to handle common order-related operations, such as retrieving order lists, adding new
+/// orders, updating existing orders, and managing attachments. Exceptions are thrown for invalid inputs or when the
+/// SOAP service returns an error. </para> <para> Usage of this class requires familiarity with the SOAP service's
+/// request and response structures. Ensure that all required parameters are properly populated before invoking any
+/// methods. </para></remarks>
+/// <param name="_soap"></param>
+public class OrderService(Service1Soap _soap)
 {
-
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public OrderService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Retrieves a list of orders based on the provided request parameters.

--- a/Midnight.SOAP.SDK/OrderVersionDetailService.cs
+++ b/Midnight.SOAP.SDK/OrderVersionDetailService.cs
@@ -1,7 +1,5 @@
 ﻿using Midnight.SOAP.SDK.RequestObjects.OrderVersionDetailInputs;
 using Midnight.SOAP.SDK.ResponseObjects.OrderVersionDetailOutputs;
-using Midnight.SOAP.SDK.ResponseObjects.OrderVersionOutputs;
-using Midnight.SOAP.SDK.ResponseObjects.SettingOutputs;
 using Midnight.SOAP.SDK.Utilities;
 using MidnightAPI;
 using Serilog;
@@ -9,22 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with order version details via SOAP requests.
+/// Provides methods for managing order version details through SOAP-based asynchronous operations.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service includes functionality to retrieve, insert, and update order version details using
-/// asynchronous SOAP operations. Each method requires valid authentication credentials and properly formatted request
-/// bodies.</remarks>
-public class OrderVersionDetailService
+/// <remarks>This service includes functionality to retrieve, insert, update, delete, and query estimated time
+/// details for order versions. Each method communicates with a SOAP service, sending serialized XML requests and
+/// processing the corresponding responses. Exceptions are thrown for non-zero return codes or unexpected errors, with
+/// detailed logging for debugging purposes.</remarks>
+/// <param name="_soap"></param>
+public class OrderVersionDetailService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-
-    public OrderVersionDetailService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
     
     /// <summary>
     /// Retrieves a list of order version details asynchronously via a SOAP request.

--- a/Midnight.SOAP.SDK/OrderVersionDropService.cs
+++ b/Midnight.SOAP.SDK/OrderVersionDropService.cs
@@ -7,21 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with the SOAP service to manage order version drops.
+/// Provides methods for managing order version drops through SOAP requests, including retrieving, inserting, updating,
+/// and deleting order version drops. IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service includes functionality to retrieve, insert, and update order version drop information
-/// via asynchronous SOAP requests. Each method requires authentication and properly formatted request objects. Ensure
-/// that the provided parameters meet the required conditions to avoid exceptions.</remarks>
-public class OrderVersionDropService
+/// <remarks>This service interacts with a SOAP-based API to perform operations related to order version drops.
+/// Each method sends a SOAP request, logs the request and response details for debugging purposes, and processes the
+/// response to return the result.  Ensure that valid authentication credentials are provided in the <see
+/// cref="ValidationSoapHeader"/> parameter for all operations.</remarks>
+/// <param name="_soap"></param>
+public class OrderVersionDropService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public OrderVersionDropService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     /// <summary>
     /// Sends a SOAP request to retrieve a list of drops associated with a specific order version and parses the

--- a/Midnight.SOAP.SDK/OrderVersionInventoryService.cs
+++ b/Midnight.SOAP.SDK/OrderVersionInventoryService.cs
@@ -7,22 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with the Order Version Inventory SOAP service,  including retrieving and updating
-/// inventory data.
+/// Provides methods for interacting with order version inventory records via SOAP requests.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service acts as a client for the SOAP-based Order Version Inventory API,  enabling operations
-/// such as fetching inventory lists and updating inventory records.  It requires authentication via a <see
-/// cref="ValidationSoapHeader"/> and uses XML-based  request and response payloads.</remarks>
-public class OrderVersionInventoryService
+/// <remarks>This service facilitates operations such as retrieving, updating, and inserting order version
+/// inventory records. Each method communicates with a SOAP service, handling serialization of request objects to XML
+/// and deserialization of responses into strongly-typed result objects. Exceptions are thrown for failed operations,
+/// with detailed error information included.</remarks>
+/// <param name="_soap"></param>
+public class OrderVersionInventoryService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public OrderVersionInventoryService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
     
     /// <summary>
     /// Retrieves a list of order version inventory records asynchronously via a SOAP request.

--- a/Midnight.SOAP.SDK/OrderVersionPostageService.cs
+++ b/Midnight.SOAP.SDK/OrderVersionPostageService.cs
@@ -7,19 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with the Order Version Postage service via SOAP.
+/// Provides methods for managing postage information related to order versions via SOAP requests.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service allows clients to insert and update postage information for order versions. It
-/// communicates with the SOAP endpoint using the <see cref="Service1SoapClient"/>.</remarks>
-public class OrderVersionPostageService
+/// <remarks>This service class includes methods to insert, update, and retrieve postage information for specific
+/// order versions. Each method communicates with a SOAP service, sending serialized XML requests and processing the
+/// responses. Exceptions are thrown for any failures, including SOAP errors or non-zero return codes in the
+/// responses.</remarks>
+/// <param name="_soap"></param>
+public class OrderVersionPostageService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public OrderVersionPostageService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to insert postage information for a specific order version and returns the result.

--- a/Midnight.SOAP.SDK/OrderVersionService.cs
+++ b/Midnight.SOAP.SDK/OrderVersionService.cs
@@ -8,23 +8,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for managing order versions, including listing, adding, updating, and deleting versions.
+/// Provides methods for managing order versions through SOAP requests.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service interacts with a SOAP-based API to perform operations on order versions.  Each method
-/// requires a valid <see cref="ValidationSoapHeader"/> for authentication and expects request objects  containing the
-/// necessary parameters. Ensure that unused properties in request objects are set to <see langword="null"/>  to avoid
-/// unintended behavior.</remarks>
-public class OrderVersionService
+/// <remarks>This service facilitates operations such as retrieving, adding, updating, deleting, and completing
+/// order versions by interacting with an external SOAP-based API. Each method in this service handles the conversion of
+/// request objects to XML, sends the SOAP request, and processes the response into strongly-typed result objects.
+/// Exceptions are logged and rethrown for error handling.</remarks>
+/// <param name="_soap"></param>
+public class OrderVersionService(Service1Soap _soap)
 {
-
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public OrderVersionService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     /// <summary>
     /// Sends a SOAP request to retrieve and order a list of versions based on the provided input parameters.

--- a/Midnight.SOAP.SDK/PurchaseOrderService.cs
+++ b/Midnight.SOAP.SDK/PurchaseOrderService.cs
@@ -8,20 +8,17 @@ namespace Midnight.SOAP.SDK;
 
 /// <summary>
 /// Provides methods for creating, retrieving, and updating purchase orders via SOAP requests.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
 /// <remarks>This service acts as a client for interacting with a SOAP-based API to manage purchase orders.  It
-/// includes methods for creating new purchase orders, retrieving a list of purchase orders,  and updating existing
-/// purchase orders. Each method handles serialization of request objects  to XML, sends the SOAP request, and
-/// deserializes the response into strongly-typed result objects.</remarks>
-public class PurchaseOrderService
+/// includes methods for creating new purchase orders, retrieving lists of existing purchase orders,  and updating
+/// purchase orders. Each method handles serialization of request objects to XML,  communication with the SOAP service,
+/// and deserialization of the response into strongly-typed objects.  Exceptions are thrown for invalid input or when
+/// the SOAP service returns an error.  Ensure that the provided authentication headers and request objects are valid
+/// and complete.</remarks>
+/// <param name="_soap"></param>
+public class PurchaseOrderService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public PurchaseOrderService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to create a new purchase order and returns the result of the operation.

--- a/Midnight.SOAP.SDK/RequestObjects/CustomerInputs/CustomerNonProfitAuthNumberListRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/CustomerInputs/CustomerNonProfitAuthNumberListRequestBody.cs
@@ -6,7 +6,7 @@ namespace Midnight.SOAP.SDK.RequestObjects.CustomerInputs;
 [XmlRoot("CustomerList")]
 public class CustomerNonProfitAuthNumberListRequestBody
 {
-    public CustomerNonProfitAuthNumberListInputParameter InputParameter { get; set; }
+    public required CustomerNonProfitAuthNumberListInputParameter InputParameter { get; set; }
 }
 
 public class CustomerNonProfitAuthNumberListInputParameter

--- a/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/OrderVersionOtherJobCostInsertRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/OrderVersionOtherJobCostInsertRequestBody.cs
@@ -8,7 +8,7 @@ public class OrderVersionOtherJobCostInsertRequestBody
 {
     public required int OrderID { get; set; }
     public required int VersionID { get; set; }
-    public required DateOnly Date { get; set; }
+    public required string Date { get; set; } = string.Empty;
     public string? Type { get; set; }
     public string? Source { get; set; }
     public decimal? Quantity { get; set; } = decimal.Zero;

--- a/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/ProductionTimeEntryRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/ProductionTimeEntryRequestBody.cs
@@ -1,18 +1,16 @@
-﻿using System.ComponentModel.DataAnnotations;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
 namespace Midnight.SOAP.SDK.RequestObjects.JobCostInputs;
 
 [XmlRoot("JobCostProductionTimeEntry")]
 public class ProductionTimeEntryRequestBody
 {
-    public required ProductionTimeEntryinputParameter InputParameter { get; set; }
+    public required ProductionTimeEntryInputParameter InputParameter { get; set; }
 }
 
-public class ProductionTimeEntryinputParameter
+public class ProductionTimeEntryInputParameter
 {
-    [Required]
-    public int EmployeeID { get; set; }
+    public required int EmployeeID { get; set; }
     public string? JobNumber { get; set; }
     public int? VersionSuffix { get; set; }
     public string? ServiceName { get; set; }

--- a/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/ServiceTimeEntryRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/JobCostInputs/ServiceTimeEntryRequestBody.cs
@@ -6,19 +6,16 @@ namespace Midnight.SOAP.SDK.RequestObjects.JobCostInputs;
 [XmlRoot("JobCostServiceTimeEntryRequest")]
 public class ServiceTimeEntryRequestBody
 {
-    [Required]
-    public int EmployeeID { get; set; }
-    [Required]
-    public DateOnly ActivityDate { get; set; }
-    public List<ServiceTimeEntryRequestItem> JobCostItems { get; set; }
+    public required int EmployeeID { get; set; }
+    public required string ActivityDate { get; set; }
+    public required List<ServiceTimeEntryRequestItem> JobCostItems { get; set; }
 }
 
 public class ServiceTimeEntryRequestItem
 {
-    [Required]
-    public string? OperationCode { get; set; }
-    public int HelpersCount { get; set; }
-    public decimal TotalTime { get; set; }
+    public required string OperationCode { get; set; }
+    public required int HelpersCount { get; set; }
+    public required decimal TotalTime { get; set; }
     public string? JobComment { get; set; }
     public int? OrderID { get; set; }
 }

--- a/Midnight.SOAP.SDK/RequestObjects/OrderInputs/OrderShipmentNewRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/OrderInputs/OrderShipmentNewRequestBody.cs
@@ -8,8 +8,8 @@ public class OrderShipmentNewRequestBody
     public required int OrderID { get; set; }
     public required int VersionID { get; set; }
     public int? LocationID { get; set; }
-    public required string TrackingNo { get; set; }
-    public required DateOnly ShippedDate { get; set; }
+    public required string TrackingNo { get; set; } = string.Empty;
+    public required string ShippedDate { get; set; } = string.Empty;
     public decimal? Weight { get; set; } = decimal.Zero;
     public decimal? Cost { get; set; } = decimal.Zero;
     public string? ServiceType { get; set; }

--- a/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofAttachmentListRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofAttachmentListRequestBody.cs
@@ -6,10 +6,10 @@ namespace Midnight.SOAP.SDK.RequestObjects.ProofingInputs;
 [XmlRoot("RequestAttachmentList")]
 public class ProofAttachmentListRequestBody
 {
-    public required ProofAttachmentLIstInputParameter InputParameter { get; set; }
+    public required ProofAttachmentListInputParameter InputParameter { get; set; }
 }
 
-public class ProofAttachmentLIstInputParameter
+public class ProofAttachmentListInputParameter
 {
     public required int RequestID { get; set; }
 }

--- a/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofNewRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofNewRequestBody.cs
@@ -7,20 +7,18 @@ namespace Midnight.SOAP.SDK.RequestObjects.ProofingInputs;
 [XmlRoot("RequestNew")]
 public class ProofNewRequestBody
 {
-    public required ProofNewRequestInputParameter InputParameter { get; set; }
+    public required ProofNewInputParameter InputParameter { get; set; }
 }
 
-public class ProofNewRequestInputParameter
+public class ProofNewInputParameter
 {
     public required List<RequestNew> Requests { get; set; } = new List<RequestNew>();
 }
 
 public class RequestNew
 {
-    [Required]
-    public DateOnly RequestDate { get; set; }
-    [Required]
-    public int CustomerID { get; set; }
+    public required string RequestDate { get; set; }
+    public required int CustomerID { get; set; }
     public int? EstimateID { get; set; }
     public int? VersionID { get; set; }
     public int? OrderVersionDetailID { get; set; }

--- a/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofUpdateRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/ProofingInputs/ProofUpdateRequestBody.cs
@@ -13,7 +13,7 @@ public class ProofUpdateInputParameter
 {
     [XmlArray("Requests")]
     [XmlArrayItem("Request")]
-    public List<ProofUpdate> Requests { get; set; } = new List<ProofUpdate>();
+    public required List<ProofUpdate> Requests { get; set; } = new List<ProofUpdate>();
 }
 
 public class ProofUpdate

--- a/Midnight.SOAP.SDK/RequestObjects/VendorContactInputs/VendorContactInsertRequestBody.cs
+++ b/Midnight.SOAP.SDK/RequestObjects/VendorContactInputs/VendorContactInsertRequestBody.cs
@@ -11,10 +11,10 @@ public class VendorContactInsertRequestBody
 
 public class VendorContactInsertInputParameter
 {
-    public required List<VendorContact> VendorContacts { get; set; }
+    public required List<VendorContactInsert> VendorContacts { get; set; }
 }
 
-public class VendorContact
+public class VendorContactInsert
 {
     public required int VendorID { get; set; }
     public string? Salutation { get; set; }

--- a/Midnight.SOAP.SDK/ResponseObjects/ProofingOutputs/ProofUpdateResult.cs
+++ b/Midnight.SOAP.SDK/ResponseObjects/ProofingOutputs/ProofUpdateResult.cs
@@ -4,10 +4,10 @@ using System.Xml.Serialization;
 
 namespace Midnight.SOAP.SDK.ResponseObjects.ProofingOutputs;
 
+[XmlRoot("Result")]
 public class ProofUpdateResult
 {
-    [XmlArray("Results")]
-    [XmlArrayItem("Result")]
+    [XmlElement("Results")]
     public List<Result> Results { get; set; } = new List<Result>();
 }
 

--- a/Midnight.SOAP.SDK/SettingService.cs
+++ b/Midnight.SOAP.SDK/SettingService.cs
@@ -7,22 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with Admin Setting methods of PrintReach's Midnight MIS via SOAP requests.
+/// Provides methods for interacting with a SOAP service to retrieve various types of data, such as company lists,
+/// operations, warehouses, and more. IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
 /// <remarks>This service acts as a client for a SOAP-based API, offering asynchronous methods to send requests
-/// and process responses for different types of data queries. Each method in this service handles serialization of
-/// request objects to XML, communication with the SOAP service, and deserialization of responses into strongly-typed
-/// result objects. If a SOAP operation fails, exceptions are thrown with detailed error information.</remarks>
-public class SettingService
+/// and process responses. Each method in this service is responsible for serializing the request body to XML, sending
+/// the request to the SOAP service, and deserializing the response. If the SOAP service returns an error (non-zero
+/// return code), an exception is thrown with detailed error information.</remarks>
+/// <param name="_soap"></param>
+public class SettingService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public SettingService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     /// <summary>
     /// Sends a SOAP request to retrieve a list of companies based on the provided request parameters.

--- a/Midnight.SOAP.SDK/Utilities/SoapClient.cs
+++ b/Midnight.SOAP.SDK/Utilities/SoapClient.cs
@@ -1,0 +1,15 @@
+﻿using MidnightAPI;
+using Serilog;
+
+namespace Midnight.SOAP.SDK.Utilities;
+
+public class SoapClient
+{
+    public static Service1Soap Configure()
+    {
+        var endpointConfig = Service1SoapClient.EndpointConfiguration.Service1Soap;
+        Service1SoapClient client = new Service1SoapClient(endpointConfig);
+
+        return client;
+    }
+}

--- a/Midnight.SOAP.SDK/VendorContactService.cs
+++ b/Midnight.SOAP.SDK/VendorContactService.cs
@@ -7,22 +7,16 @@ using Serilog;
 namespace Midnight.SOAP.SDK;
 
 /// <summary>
-/// Provides methods for interacting with vendor contact data through a SOAP-based service.
+/// Provides methods for interacting with vendor contact data through SOAP-based operations.
+/// IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This service facilitates operations such as inserting, updating, and retrieving vendor contact
-/// information. Each method communicates with the SOAP service using the provided authentication header and request
-/// body. Exceptions are thrown for failed operations, and detailed error information is included in the exception
-/// messages.</remarks>
-public class VendorContactService
+/// <remarks>This service facilitates the insertion, update, and retrieval of vendor contact information by
+/// communicating with a SOAP service. Each method in this class performs XML serialization of the request body, sends
+/// the SOAP request, and processes the response. Exceptions are thrown for non-zero return codes or errors during the
+/// SOAP communication.</remarks>
+/// <param name="_soap"></param>
+public class VendorContactService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public VendorContactService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
-
 
     /// <summary>
     /// Sends a SOAP request to insert a vendor contact and returns the result of the operation.

--- a/Midnight.SOAP.SDK/VendorService.cs
+++ b/Midnight.SOAP.SDK/VendorService.cs
@@ -8,21 +8,15 @@ namespace Midnight.SOAP.SDK;
 
 /// <summary>
 /// Provides methods for interacting with a SOAP-based vendor service, including operations for inserting, updating, and
-/// retrieving vendor information.
+/// retrieving vendor information. IMPORTANT: Must inject output of Utilities.SoapClient.Configure().
 /// </summary>
-/// <remarks>This class acts as a client for a SOAP service, enabling operations such as vendor insertion, vendor
-/// updates, and vendor list retrieval. Each method sends a SOAP request and processes the response, logging relevant
-/// details for debugging purposes. Exceptions are thrown for failed operations, including cases where the service
-/// returns an error code.</remarks>
-public class VendorService
+/// <remarks>This class acts as a client for a SOAP-based vendor service, enabling the execution of vendor-related
+/// operations such as insertion, updates, and retrievals. Each method sends a SOAP request, logs the request and
+/// response details for debugging purposes, and handles any errors that occur during the operation. Exceptions are
+/// thrown for failed operations, including cases where the service returns a non-zero return code.</remarks>
+/// <param name="_soap"></param>
+public class VendorService(Service1Soap _soap)
 {
-    private readonly Service1SoapClient.EndpointConfiguration _soapConfig;
-    private readonly Service1Soap _soap;
-    public VendorService()
-    {
-        _soapConfig = new Service1SoapClient.EndpointConfiguration();
-        _soap = new Service1SoapClient(_soapConfig);
-    }
 
     /// <summary>
     /// Sends a SOAP request to insert a vendor and returns the result of the operation.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - **Strongly-Typed Requests**: Uses strongly-typed request objects to ensure type safety and reduce runtime errors caused by string concatenated XML inputs.
 - **Strongly-Typed Responses**: Converts Midnight API XML response strings into strongly-typed C# models.
 - **User-Defined Fields Support**: The SDK provides a flexible UserDefinedFields class, where each UDF property (UDF1 to UDF30) is implemented using the `UDFValue` class. This allows each field to accept and serialize values as string, decimal, integer, date, or time, ensuring correct XML formatting for both requests and responses. The UDFValue class handles type conversion and serializes the value as the text content of the corresponding <UDF*> XML tag.
+- **Testing** : Includes comprehensive unit tests for all services and request/response objects, ensuring reliability and correctness.
 - **Logging**: Integrated logging for diagnostics and debugging using Serilog.
 
 ---
@@ -35,32 +36,39 @@ Install-Package Midnight.SOAP.SDK
 
 ## Usage
 
+### 0. Soap Client Configuration
+```csharp
+using Midnight.SOAP.SDK.Utilities;
+
+var soapClient = SoapClient.Configure();
+```
+
 ### 1. Service Initializations
 ```csharp
 using Midnight.SOAP.SDK;
 
-var authService = new AuthenticationService();
-var customerService = new CustomerService();
-var customerContactService = new CustomerContactService();
-var djbService = new DJBService();
-var estimateService = new EstimateService();
-var inventoryItemService = new InventoryItemService();
-var inventoryService = new InventoryService();
-var jobCostingService = new JobCostingService();
-var orderService = new OrderService();
-var orderVersionService = new OrderVersionService();
-var orderVersionDetailService = new OrderVersionDetailService();
-var orderVersionDropService = new OrderVersionDropService();
-var orderVersionInventoryService = new OrderVersionInventoryService();
-var orderVersionPostageService = new OrderVersionPostageService();
+var authService = new AuthenticationService(soapClient);
+var customerService = new CustomerService(soapClient);
+var customerContactService = new CustomerContactService(soapClient);
+var djbService = new DJBService(soapClient);
+var estimateService = new EstimateService(soapClient);
+var inventoryItemService = new InventoryItemService(soapClient);
+var inventoryService = new InventoryService(soapClient);
+var jobCostingService = new JobCostingService(soapClient);
+var orderService = new OrderService(soapClient);
+var orderVersionService = new OrderVersionService(soapClient);
+var orderVersionDetailService = new OrderVersionDetailService(soapClient);
+var orderVersionDropService = new OrderVersionDropService(soapClient);
+var orderVersionInventoryService = new OrderVersionInventoryService(soapClient);
+var orderVersionPostageService = new OrderVersionPostageService(soapClient);
 
 // ProofingService is the wrapper for "Request" api calls, making it clearer what the service is used for.
-var proofingService = new ProofingService();
+var proofingService = new ProofingService(soapClient);
 
-var purchaseOrderService = new PurchaseOrderService();
-var settingsService = new SettingService();
-var venderService = new VendorService();
-var vendorContactService = new VendorContactService();
+var purchaseOrderService = new PurchaseOrderService(soapClient);
+var settingsService = new SettingService(soapClient);
+var venderService = new VendorService(soapClient);
+var vendorContactService = new VendorContactService(soapClient);
 
 ```
 
@@ -194,10 +202,9 @@ For questions or support, please open an issue on the repository.
 
 ## Roadmap
 The roadmap for **Midnight.SOAP.SDK** includes:
-- Add unit tests for all services.
 - Implement custom services for common combinations of other services.
 - Implement Aggregation services for reporting, analytics, and invoicing integrations.
 - Implement additional features as requested by the community.
 - Enhance documentation with more examples and use cases.
 
-**Midnight.SOAP.SDK** makes integrating with the Midnight SOAP API fast, reliable, and developer-friendly.
+**Midnight.SOAP.SDK makes integrating with the Midnight SOAP API fast, reliable, and developer-friendly.**

--- a/automation/commit-msg
+++ b/automation/commit-msg
@@ -18,7 +18,7 @@
 # This example catches duplicate Signed-off-by lines.
 
 #!/usr/bin/env bash
-if ! head -1 "$1" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert|init|dependencies|peerDependencies|devDependencies|metadata)(\(.+?\))?: .{1,}$"; then
+if ! head -1 "$1" | grep -qE "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9\-]+\))?(!)?: [^\s].{0,48}$"; then
     echo "Aborting commit. Your commit message is invalid." >&2
     exit 1
 fi


### PR DESCRIPTION
#BREAKING CHANGES:
- Swapped in-service Service1SoapClient initialization to Utilities.SoapClient.Configure() method. This allows us to now inject the Service1SoapClient as the Service1Soap interface exposed by the MidnightAPI connected service.
- changed DateOnly types to strings for simplicity
- camelcase mishaps in request and response class names
- fixed ambiguous class names

#FEATURES:
- Added success and failure unit tests for every service method exposed. 
- CI/CD workflow now requires all tests to pass before any further steps will be attempted

#DOCS:
- Updated README to include initialization example for the Utilities.SoapClient.Configure() method.
- Updated Service initialization examples
